### PR TITLE
v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [1.10.0] - 2026-02-13
+
+### Added
+
+- `NiceHttp.validate_response(resp, expected_structure, options)` to validate JSON response structure using NiceHash.compare_structure. Optional `include_diff: true` adds a diff to the result when validation fails.
+- README section "Testing with generated data" (reproducible seed, generate_n, UUID with nice_hash/string_pattern).
+- README section "Validating API responses" (compare_structure, diff, pattern validation).
+- README "Related gems" note for nice_hash (v1.19+) and string_pattern (v2.4+).
+
+### Changed
+
+- **Dependency:** nice_hash is now required as `~> 1.19`, `>= 1.19.0` (was `~> 1.18`, `>= 1.18.4`). Upgrade nice_hash to 1.19+ when upgrading nice_http.
+- Headers initialization: only calls `@headers.generate` when `@headers` is a Hash and responds to `generate`, otherwise duplicates headers without generating (avoids errors in edge cases).
+
+### Removed
+
+- Removed dead code branch for Ruby < 2.6.0 in response handling (nice_http already requires Ruby >= 2.7).

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 group :test do
-  gem 'rake'
-  gem 'rspec'
-  gem 'coveralls_reborn', '~> 0.27.0', require: false
+  gem "rake"
+  gem "rspec"
+  gem "sinatra", "~> 3.0"
+  gem "webrick"
+  gem "coveralls_reborn", "~> 0.27.0", require: false
 end
 
 # Specify your gem's dependencies in mygem.gemspec

--- a/README.md
+++ b/README.md
@@ -20,34 +20,37 @@ NiceHttp is able to use hashes as requests data and uses the Request Hash struct
 
 **On the next link you have a full example using nice_http and RSpec to test REST APIs, Uber API and Reqres API: https://github.com/MarioRuiz/api-testing-example**
 
-To be able to generate random requests take a look at the documentation for nice_hash gem: https://github.com/MarioRuiz/nice_hash
-
-Example that creates 1000 good random and unique requests to register an user and test that the validation of the fields are correct by the user was able to be registered. Send 800 requests where just one field is wrong and verify the user was not able to be created: https://gist.github.com/MarioRuiz/824d7a462b62fd85f02c1a09455deefb
+**Related gems:** NiceHttp uses [nice_hash](https://github.com/MarioRuiz/nice_hash) (v1.19+) for request/response hashes (e.g. `resp.data.json`, `set_values`, `nice_merge`) and for generating headers. [string_pattern](https://github.com/MarioRuiz/string_pattern) (v2.4+) is used by nice_hash for pattern-based string generation and validation. To generate random or pattern-based request data, see the [nice_hash documentation](https://github.com/MarioRuiz/nice_hash). Example: 1000 valid requests + 800 with one wrong field to test validation — [gist](https://gist.github.com/MarioRuiz/824d7a462b62fd85f02c1a09455deefb).
 
 # Table of Contents
 
-- [Installation](#Installation)
-- [A very simple first example](#A-very-simple-first-example)
-- [Create a connection](#Create-a-connection)
-- [Creating requests](#Creating-requests)
-- [Responses](#Responses)
-    - [Async Responses](#Async-Responses)
-- [Special settings](#Special-settings)
-- [Authentication requests](#Authentication-requests)
-    - [Basic Authentication](#Basic-Authentication)
-    - [OpenID](#OpenID)
-    - [OAuth2](#OAuth2)
-    - [JWT Token](#JWT-Token)
+- [NiceHttp](#nicehttp)
+- [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+  - [A very simple first example](#a-very-simple-first-example)
+  - [Create a connection](#create-a-connection)
+  - [Creating requests](#creating-requests)
+  - [Responses](#responses)
+    - [Async responses](#async-responses)
+  - [Special settings](#special-settings)
+  - [Authentication requests](#authentication-requests)
+    - [Basic Authentication](#basic-authentication)
+    - [OpenID](#openid)
+    - [OAuth2](#oauth2)
+    - [JWT token](#jwt-token)
     - [lambda on headers](#lambda-on-headers)
-- [Http logs](#Http-logs)
-    - [Multithreading](#Multithreading)
-- [Http stats](#Http-stats)
-- [Tips](#Tips)
-    - [Download a file](#Download-a-file)
-    - [Send multipart content](#Send-multipart-content)
-    - [Send x-www-form-urlencoded](#Send-x-www-form-urlencoded)
-- [Contributing](#Contributing)
-- [License](#License)
+  - [Http logs](#http-logs)
+    - [Multithreading](#multithreading)
+  - [Http stats](#http-stats)
+  - [Testing with generated data](#testing-with-generated-data)
+  - [Validating API responses](#validating-api-responses)
+  - [Tips](#tips)
+    - [Download a file](#download-a-file)
+    - [Send multipart content](#send-multipart-content)
+    - [Send x-www-form-urlencoded](#send-x-www-form-urlencoded)
+  - [Running tests](#running-tests)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Installation
 
@@ -98,6 +101,9 @@ http3 = NiceHttp.new my_reqres_server
 
 ```
 
+
+**Connection errors ("Too many open files")**  
+If you see "Too many open files" when creating connections (e.g. with many threads), NiceHttp will retry connection creation a few times with backoff. You can set `NiceHttp.connection_retry_attempts` (default 3) and `NiceHttp.connection_retry_base_delay` (default 1.0 seconds), or pass `connection_retry_attempts` and `connection_retry_base_delay` in the options hash when creating a connection. For long-running or multi-threaded usage, prefer reusing one connection per thread and calling `close` when finished.
 
 You can specify all the defaults you will be using when creating connections by using the NiceHttp methods, in this example, http1 and http2 will be connecting to reqres.in with the default parameters and http3 to example.com:
 
@@ -748,6 +754,46 @@ NiceHttp.add_stats(:customer, :create, started, Time.now, customer_name)
 
 This will generate an items key that will contain an array of the values you added.
 
+## Testing with generated data
+
+When you build request hashes with [nice_hash](https://github.com/MarioRuiz/nice_hash) patterns (in `data`, `headers`, or `values_for`), you can:
+
+* **Reproducible tests:** Use `seed` so the same request is generated every time:
+  ```ruby
+  req = { path: "/api/users", data: { name: :"10-20:L", email: :"20-40:@" } }
+  resp = http.post req.generate(seed: 42)  # same payload every run
+  ```
+
+* **Batch generation:** Generate many different request hashes in one go (e.g. for load or boundary tests):
+  ```ruby
+  template = { path: "/api/users", data: { name: :"10-20:L", job: :"leader|developer" } }
+  requests = template.generate_n(5, :correct)  # 5 different hashes
+  requests.each { |r| http.post r }
+  ```
+
+* **UUIDs:** Use the `:uuid` shorthand (string_pattern 2.4+) in your request data:
+  ```ruby
+  resp = http.post(path: "/api/items", data: { id: :uuid, name: "Item" })
+  ```
+
+## Validating API responses
+
+You can validate JSON responses against a structure or patterns using [nice_hash](https://github.com/MarioRuiz/nice_hash):
+
+* **Structure comparison:** Check that the response has the expected keys and nested structure:
+  ```ruby
+  expected = { user: { name: "xxx", id: 1 } }
+  NiceHash.compare_structure(expected, resp.data.json)  # => true/false
+  ```
+
+* **Diff for assertions:** Get dot-notation differences for clearer failure messages:
+  ```ruby
+  diff = NiceHash.diff(expected, resp.data.json)
+  # => { "user.name" => { expected: "Alice", got: "Bob" } } or {}
+  ```
+
+* **Pattern validation:** If your expected structure uses nice_hash patterns (e.g. `:"10:N"`, ranges), use `validate` to check that response values match those patterns.
+
 ## Tips
 
 ### Download a file
@@ -794,6 +840,17 @@ Example posting a csv file:
       }
     }
 ```
+
+## Running tests
+
+Run the test suite with:
+
+```bash
+bundle install
+bundle exec rspec
+```
+
+By default, a **local Sinatra fake API** is started on ports 4567 and 4568 so specs do not depend on external services (reqres.in, Replit, example.com). Set `USE_FAKE_API=false` to use real external hosts instead (not recommended for CI).
 
 ## Contributing
 

--- a/lib/nice_http.rb
+++ b/lib/nice_http.rb
@@ -23,13 +23,15 @@ require_relative "nice_http/inherited"
 require_relative "nice_http/save_stats"
 require_relative "nice_http/close"
 require_relative "nice_http/initialize"
+require_relative "nice_http/validate_response"
 
 ######################################################
-# Attributes you can access using NiceHttp.the_attribute:  
-#   :host, :port, :ssl, :timeout, :headers, :debug, :log, :log_headers, :proxy_host, :proxy_port,  
-#   :last_request, :last_response, :request_id, :use_mocks, :connections,  
+# Attributes you can access using NiceHttp.the_attribute:
+#   :host, :port, :ssl, :timeout, :headers, :debug, :log, :log_headers, :proxy_host, :proxy_port,
+#   :last_request, :last_response, :request_id, :use_mocks, :connections,
 #   :active, :auto_redirect, :values_for, :create_stats, :stats, :capture, :captured, :request, :requests,
-#   :async_wait_seconds, :async_header, :async_completed, :async_resource, :async_status
+#   :async_wait_seconds, :async_header, :async_completed, :async_resource, :async_status,
+#   :connection_retry_attempts, :connection_retry_base_delay
 #
 # @attr [String] host The host to be accessed
 # @attr [Integer] port The port number
@@ -38,12 +40,12 @@ require_relative "nice_http/initialize"
 # @attr [Hash] headers Contains the headers you will be using on your connection
 # @attr [Boolean] debug In case true shows all the details of the communication with the host
 # @attr [String] log_path The path where the logs will be stored. By default empty string.
-# @attr [String, Symbol] log :fix_file, :no, :screen, :file, "path and file name".  
-#   :fix_file, will log the communication on nice_http.log. (default).  
-#   :no, will not generate any logs.  
-#   :screen, will print the logs on the screen.  
-#   :file, will be generated a log file with name: nice_http_YY-mm-dd-HHMMSS.log.  
-#   :file_run, will generate a log file with the name where the object was created and extension .log, fex: myfile.rb.log  
+# @attr [String, Symbol] log :fix_file, :no, :screen, :file, "path and file name".
+#   :fix_file, will log the communication on nice_http.log. (default).
+#   :no, will not generate any logs.
+#   :screen, will print the logs on the screen.
+#   :file, will be generated a log file with name: nice_http_YY-mm-dd-HHMMSS.log.
+#   :file_run, will generate a log file with the name where the object was created and extension .log, fex: myfile.rb.log
 #   String the path and file name where the logs will be stored.
 # @attr [String] log_file path and file name where the logs will be stored. (only reader)
 # @attr [Symbol] log_headers. :all, :partial, :none (default :all) If :all will log all the headers. If :partial will log the last 10 characters. If :none no headers.
@@ -61,10 +63,10 @@ require_relative "nice_http/initialize"
 # @attr [Hash] response Contains the full response hash
 # @attr [Integer] num_redirects Number of consecutive redirections managed
 # @attr [Hash] headers The updated headers of the communication
-# @attr [Hash] cookies Cookies set. The key is the path (String) where cookies are set and the value a Hash with pairs of cookie keys and values, example:  
+# @attr [Hash] cookies Cookies set. The key is the path (String) where cookies are set and the value a Hash with pairs of cookie keys and values, example:
 #   { '/' => { "cfid" => "d95adfas2550255", "amddom.settings" => "doom" } }
-# @attr [Logger] logger An instance of the Logger class where logs will be stored. You can access on anytime to store specific data, for example:  
-#   my_http.logger.info "add this to the log file"  
+# @attr [Logger] logger An instance of the Logger class where logs will be stored. You can access on anytime to store specific data, for example:
+#   my_http.logger.info "add this to the log file"
 #   @see https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html
 # @attr [Hash] values_for The default values to set on the data in case not specified others
 # @attr [Boolean] create_stats If true, NiceHttp will create stats of the http communication and store them on NiceHttp.stats hash
@@ -101,7 +103,8 @@ class NiceHttp
     attr_accessor :host, :port, :ssl, :timeout, :headers, :debug, :log_path, :log, :proxy_host, :proxy_port, :log_headers,
                   :last_request, :last_response, :request, :request_id, :use_mocks, :connections,
                   :active, :auto_redirect, :log_files, :values_for, :create_stats, :stats, :capture, :captured, :requests,
-                  :async_wait_seconds, :async_header, :async_completed, :async_resource, :async_status
+                  :async_wait_seconds, :async_header, :async_completed, :async_resource, :async_status,
+                  :connection_retry_attempts, :connection_retry_base_delay
   end
 
   at_exit do

--- a/lib/nice_http/initialize.rb
+++ b/lib/nice_http/initialize.rb
@@ -33,6 +33,9 @@ class NiceHttp
   #             async_completed -- string (default empty string)
   #             async_resource -- string (default empty string)
   #             async_status -- string (default empty string)
+  #             connection_retry_attempts -- positive integer (default 3). When connection creation fails with "too many open files", retry up to this many times with backoff.
+  #             connection_retry_base_delay -- non-negative number, seconds (default 1.0). Base delay before each retry; jitter is added to avoid thundering herd.
+  # @note When connection creation fails with "too many open files" (EMFILE/ENFILE), the library retries up to connection_retry_attempts times with backoff. For sustained load or many threads, prefer reusing one connection per thread and calling close when done.
   # @example
   #   http2 = NiceHttp.new( host: "reqres.in", port: 443, ssl: true )
   # @example
@@ -69,7 +72,9 @@ class NiceHttp
     @async_completed = self.class.async_completed
     @async_resource = self.class.async_resource
     @async_status = self.class.async_status
-    
+    @connection_retry_attempts = self.class.connection_retry_attempts || 3
+    @connection_retry_base_delay = self.class.connection_retry_base_delay || 1.0
+
     #todo: set only the cookies for the current domain
     #key: path, value: hash with key is the name of the cookie and value the value
     # we set the default value for non existing keys to empty Hash {} so in case of merge there is no problem
@@ -86,7 +91,11 @@ class NiceHttp
       @port = args[:port] if args.keys.include?(:port)
       @ssl = args[:ssl] if args.keys.include?(:ssl)
       @timeout = args[:timeout] if args.keys.include?(:timeout)
-      @headers = args[:headers].dup if args.keys.include?(:headers)
+      # Keep object reference when it has .generate (e.g. nice_hash); otherwise dup to avoid mutating caller's hash
+      if args.keys.include?(:headers)
+        h = args[:headers]
+        @headers = (h.is_a?(Hash) && h.respond_to?(:generate)) ? h : h.dup
+      end
       @values_for = args[:values_for].dup if args.keys.include?(:values_for)
       @debug = args[:debug] if args.keys.include?(:debug)
       @log = args[:log] if args.keys.include?(:log)
@@ -100,7 +109,9 @@ class NiceHttp
       @async_header = args[:async_header] if args.keys.include?(:async_header)
       @async_completed = args[:async_completed] if args.keys.include?(:async_completed)
       @async_resource = args[:async_resource] if args.keys.include?(:async_resource)
-      @async_status = args[:async_status] if args.keys.include?(:async_status)      
+      @async_status = args[:async_status] if args.keys.include?(:async_status)
+      @connection_retry_attempts = args[:connection_retry_attempts] if args.keys.include?(:connection_retry_attempts)
+      @connection_retry_base_delay = args[:connection_retry_base_delay] if args.keys.include?(:connection_retry_base_delay)
     end
 
     log_filename = ""
@@ -175,7 +186,7 @@ class NiceHttp
       raise InfoMissing, :log
     end
     @log_file = log_filename
-    @logger.level = Logger::INFO    
+    @logger.level = Logger::INFO
 
     if @host.to_s != "" and (@host.start_with?("http:") or @host.start_with?("https:"))
       uri = URI.parse(@host)
@@ -199,28 +210,45 @@ class NiceHttp
     raise InfoMissing, :async_completed unless @async_completed.is_a?(String) or @async_completed.nil?
     raise InfoMissing, :async_resource unless @async_resource.is_a?(String) or @async_resource.nil?
     raise InfoMissing, :async_status unless @async_status.is_a?(String) or @async_status.nil?
-    
+    raise InfoMissing, :connection_retry_attempts unless @connection_retry_attempts.is_a?(Integer) && @connection_retry_attempts >= 1
+    raise InfoMissing, :connection_retry_base_delay unless @connection_retry_base_delay.is_a?(Numeric) && @connection_retry_base_delay >= 0
+
     begin
-      if !@proxy_host.nil? && !@proxy_port.nil?
-        @http = Net::HTTP::Proxy(@proxy_host, @proxy_port).new(@host, @port)
-        @http.use_ssl = @ssl
-        @http.set_debug_output $stderr if @debug
-        @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        unless @timeout.nil?
-          @http.open_timeout = @timeout
-          @http.read_timeout = @timeout
+      attempt = 1
+      loop do
+        begin
+          if !@proxy_host.nil? && !@proxy_port.nil?
+            @http = Net::HTTP::Proxy(@proxy_host, @proxy_port).new(@host, @port)
+            @http.use_ssl = @ssl
+            @http.set_debug_output $stderr if @debug
+            @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            unless @timeout.nil?
+              @http.open_timeout = @timeout
+              @http.read_timeout = @timeout
+            end
+            @http.start
+          else
+            @http = Net::HTTP.new(@host, @port)
+            @http.use_ssl = @ssl
+            @http.set_debug_output $stderr if @debug
+            @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            unless @timeout.nil?
+              @http.open_timeout = @timeout
+              @http.read_timeout = @timeout
+            end
+            @http.start
+          end
+          break
+        rescue Exception => e
+          if connection_retryable_error?(e) && attempt < @connection_retry_attempts
+            delay = @connection_retry_base_delay + rand(0.25)
+            @logger.warn "(#{self.object_id}): Too many open files (attempt #{attempt}/#{@connection_retry_attempts}), retrying in #{delay.round(2)}s..."
+            sleep(delay)
+            attempt += 1
+          else
+            raise
+          end
         end
-        @http.start
-      else
-        @http = Net::HTTP.new(@host, @port)
-        @http.use_ssl = @ssl
-        @http.set_debug_output $stderr if @debug
-        @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        unless @timeout.nil?
-          @http.open_timeout = @timeout
-          @http.read_timeout = @timeout
-        end
-        @http.start
       end
 
       @message_server = "(#{self.object_id}):"
@@ -241,7 +269,11 @@ class NiceHttp
       @auto_redirect = auto_redirect
       # for the case we have headers following nice_hash implementation
       @headers_orig = @headers.dup
-      @headers = @headers.generate
+      @headers = if @headers.is_a?(Hash) && @headers.respond_to?(:generate)
+          @headers.generate
+        else
+          @headers.dup
+        end
 
       self.class.active += 1
       self.class.connections.push(self)
@@ -251,4 +283,19 @@ class NiceHttp
       raise stack
     end
   end
+
+  ######################################################
+  # Returns true if the exception indicates file-descriptor exhaustion (too many open files).
+  # Used to decide whether to retry connection creation.
+  ######################################################
+  def connection_retryable_error?(e)
+    return true if e.is_a?(Errno::EMFILE) || e.is_a?(Errno::ENFILE)
+    return true if e.message.to_s.downcase.include?("too many open files")
+    c = e.cause
+    return true if c && (c.is_a?(Errno::EMFILE) || c.is_a?(Errno::ENFILE))
+    return true if c && c.message.to_s.downcase.include?("too many open files")
+    false
+  end
+
+  private :connection_retryable_error?
 end

--- a/lib/nice_http/manage/response.rb
+++ b/lib/nice_http/manage/response.rb
@@ -29,22 +29,6 @@ module NiceHttpManageResponse
 
       create_stats(resp) if @create_stats
 
-      begin
-        # this is to be able to access all keys as symbols on Ruby < 2.6.0
-        if RUBY_VERSION < "2.6.0"
-          new_resp = Hash.new()
-          resp.each { |key, value|
-            if key.kind_of?(String)
-              new_resp[key.to_sym] = value
-            end
-          }
-          new_resp.each { |key, value|
-            resp[key] = value
-          }
-        end
-      rescue
-      end
-
       #for mock_responses to be able to add outside of the header like content-type for example
       if resp.kind_of?(Hash) and !resp.has_key?(:header)
         resp[:header] = {}

--- a/lib/nice_http/reset.rb
+++ b/lib/nice_http/reset.rb
@@ -50,5 +50,7 @@ class NiceHttp
     @async_completed = ""
     @async_resource = ""
     @async_status = ""
+    @connection_retry_attempts = 3
+    @connection_retry_base_delay = 1.0
   end
 end

--- a/lib/nice_http/validate_response.rb
+++ b/lib/nice_http/validate_response.rb
@@ -1,0 +1,56 @@
+class NiceHttp
+  ######################################################
+  # Validates that a response body matches an expected structure (keys and nesting).
+  # Uses NiceHash.compare_structure. Best for JSON responses.
+  #
+  # @param resp [Hash] Response object (e.g. from get/post). Must have :data (body string or Hash/Array).
+  # @param expected_structure [Hash, Array] Structure with expected keys and nesting (values can be placeholders).
+  # @param options [Hash] Optional. :include_diff => true to add a diff in the result when validation fails.
+  # @return [Hash] { ok: true } when structure matches, or { ok: false } or { ok: false, diff: Hash } when it does not.
+  # @example
+  #   resp = http.get("/api/users/1")
+  #   result = NiceHttp.validate_response(resp, { user: { name: "xxx", id: 1 } })
+  #   expect(result[:ok]).to be true
+  # @example
+  #   result = NiceHttp.validate_response(resp, expected, include_diff: true)
+  #   puts result[:diff] unless result[:ok]
+  ######################################################
+  def self.validate_response(resp, expected_structure, options = {})
+    data = resp.is_a?(Hash) ? resp[:data] : resp.data
+    parsed = if data.is_a?(String)
+        begin
+          require "json"
+          JSON.parse(data.to_s)
+        rescue JSON::ParserError
+          return { ok: false, error: "response data is not valid JSON" }
+        end
+      elsif data.is_a?(Hash) || data.is_a?(Array)
+        data
+      else
+        return { ok: false, error: "response data is missing or not JSON" }
+      end
+
+    # Normalize to symbol keys so compare_structure/diff match typical expected_structure (symbol keys)
+    parsed = deep_symbolize(parsed) if parsed.is_a?(Hash) || parsed.is_a?(Array)
+
+    ok = NiceHash.compare_structure(expected_structure, parsed)
+
+    result = { ok: ok }
+    if !ok && options[:include_diff]
+      result[:diff] = NiceHash.diff(expected_structure, parsed)
+    end
+    result
+  end
+
+  def self.deep_symbolize(obj)
+    case obj
+    when Hash
+      obj.each_with_object({}) { |(k, v), h| h[k.to_sym] = deep_symbolize(v) }
+    when Array
+      obj.map { |e| deep_symbolize(e) }
+    else
+      obj
+    end
+  end
+  private_class_method :deep_symbolize
+end

--- a/nice_http.gemspec
+++ b/nice_http.gemspec
@@ -1,21 +1,20 @@
 Gem::Specification.new do |s|
-  s.name        = 'nice_http'
-  s.version     = '1.9.8'
-  s.summary     = "NiceHttp -- simplest library for accessing and testing HTTP and REST resources. Get http logs and statistics automatically. Use hashes on your requests. Access JSON even easier."
+  s.name = "nice_http"
+  s.version = "1.10.0"
+  s.summary = "NiceHttp -- simplest library for accessing and testing HTTP and REST resources. Get http logs and statistics automatically. Use hashes on your requests. Access JSON even easier."
   s.description = "NiceHttp -- simplest library for accessing and testing HTTP and REST resources. Get http logs and statistics automatically. Use hashes on your requests. Access JSON even easier."
-  s.authors     = ["Mario Ruiz"]
-  s.email       = 'marioruizs@gmail.com'
-  s.files       = Dir["lib/nice_http/methods/*.rb"] + Dir["lib/nice_http/manage/*.rb"] + 
-                  Dir["lib/nice_http/utils/*.rb"] + Dir["lib/nice_http/*.rb"] +
-                  ["lib/nice_http.rb","LICENSE","README.md",".yardopts"]
-  s.extra_rdoc_files = ["LICENSE","README.md"]
-  s.homepage    = 'https://github.com/MarioRuiz/nice_http'
-  s.license       = 'MIT'
-  s.add_runtime_dependency 'nice_hash', '~> 1.18', '>= 1.18.4'
-  s.add_development_dependency 'rspec', '~> 3.8', '>= 3.8.0'
-  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  s.authors = ["Mario Ruiz"]
+  s.email = "marioruizs@gmail.com"
+  s.files = Dir["lib/nice_http/methods/*.rb"] + Dir["lib/nice_http/manage/*.rb"] +
+            Dir["lib/nice_http/utils/*.rb"] + Dir["lib/nice_http/*.rb"] +
+            ["lib/nice_http.rb", "LICENSE", "README.md", ".yardopts"]
+  s.extra_rdoc_files = ["LICENSE", "README.md"]
+  s.homepage = "https://github.com/MarioRuiz/nice_http"
+  s.license = "MIT"
+  s.add_runtime_dependency "nice_hash", "~> 1.19", ">= 1.19.0"
+  s.add_development_dependency "rspec", "~> 3.8", ">= 3.8.0"
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
-  s.required_ruby_version = ['>= 2.7']
+  s.required_ruby_version = [">= 2.7"]
   s.post_install_message = "Thanks for installing! Visit us on https://github.com/MarioRuiz/nice_http"
 end
-

--- a/spec/nice_http/capture_spec.rb
+++ b/spec/nice_http/capture_spec.rb
@@ -7,28 +7,28 @@ RSpec.describe NiceHttp do
   describe "capture" do
     it "captures the requests and responses" do
       klass.capture = true
-      http = klass.new("http://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.get "/"
       expect(klass.captured.size).to eq 1
       expect(klass.captured.join).to match(/^\s*\w+\s+Request\s*$/i)
       expect(klass.captured.join).to match(/^\s*RESPONSE:/i)
-      http2 = klass.new("http://www.google.com")
+      http2 = klass.new(TEST_SERVER_URL_2)
       http2.get "/"
       expect(klass.captured.join.scan(/^\s*\w+\s+Request\s*$/i).flatten.size).to eq 2
       expect(klass.captured.join.scan(/^\s*Response:/i).flatten.size).to eq 2
     end
     it "doesn't capture the requests and responses if capture set to false" do
-      http = klass.new("http://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.get "/"
       expect(klass.captured.size).to eq 0
       klass.capture = true
-      http = klass.new("http://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.get "/"
       expect(klass.captured.size).to eq 1
       expect(klass.captured.join).to match(/^\s*\w+\s+Request\s*$/i)
       expect(klass.captured.join).to match(/^\s*RESPONSE:/i)
       klass.capture = false
-      http2 = klass.new("http://www.google.com")
+      http2 = klass.new(TEST_SERVER_URL_2)
       http2.get "/"
       expect(klass.captured.join.scan(/^\s*\w+\s+Request\s*$/i).flatten.size).to eq 1
       expect(klass.captured.join.scan(/^\s*Response:/i).flatten.size).to eq 1

--- a/spec/nice_http/logs_spec.rb
+++ b/spec/nice_http/logs_spec.rb
@@ -1,15 +1,13 @@
-
 require "nice_http"
 require "English"
 
 RSpec.describe NiceHttp, "#logs" do
   let(:klass) { Class.new NiceHttp }
 
-
   describe "log files" do
     it "logs to file specified" do
       klass.log = "./example.log"
-      http = klass.new("https://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.logger.info "testing"
       content = File.read("./example.log")
       expect(content).to match /testing/
@@ -17,11 +15,11 @@ RSpec.describe NiceHttp, "#logs" do
     end
 
     it "logs to file and log_path specified" do
-      file = './tmp/example/example1.log'
+      file = "./tmp/example/example1.log"
       File.delete(file) if File.exist?(file)
-      klass.log_path = './tmp/example/'
+      klass.log_path = "./tmp/example/"
       klass.log = "./example1.log"
-      http = klass.new("https://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.logger.info "testingxl"
       content = File.read(file)
       expect(content).to match /testingxl/
@@ -29,13 +27,13 @@ RSpec.describe NiceHttp, "#logs" do
     end
 
     it "logs to file specified even when two connections pointing to same file" do
-      klass.host = "https://example.com"
-      http1 = klass.new({log: "./example.log"})
+      klass.host = TEST_SERVER_URL
+      http1 = klass.new({ log: "./example.log" })
       http1.logger.info "testing"
       content = File.read("./example.log")
       expect(content).to match /testing/
 
-      http2 = klass.new({log: http1.log})
+      http2 = klass.new({ log: http1.log })
       http2.logger.info "example2"
       content = File.read("./example.log")
       expect(content).to match /example2/
@@ -53,7 +51,7 @@ RSpec.describe NiceHttp, "#logs" do
 
     it "logs to nice_http.log when :fix_file specified" do
       klass.log = :fix_file
-      http = klass.new("https://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.logger.info "testing"
       content = File.read("./nice_http.log")
       expect(content).to match /testing/
@@ -61,10 +59,10 @@ RSpec.describe NiceHttp, "#logs" do
     end
 
     it "logs to nice_http.log when :fix_file and file_path specified" do
-      file = './tmp/example/nice_http.log'
-      klass.log_path = './tmp/example/'
+      file = "./tmp/example/nice_http.log"
+      klass.log_path = "./tmp/example/"
       klass.log = :fix_file
-      http = klass.new("https://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.logger.info "testingxd"
       content = File.read(file)
       expect(content).to match /testingxd/
@@ -73,7 +71,7 @@ RSpec.describe NiceHttp, "#logs" do
 
     it "logs to file running.log when :file_run specified" do
       klass.log = :file_run
-      http = klass.new("https://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.logger.info "testing XaXDo"
       content = File.read("./spec/nice_http/logs_spec.rb.log")
       expect(content).to match /testing XaXDo/
@@ -81,11 +79,11 @@ RSpec.describe NiceHttp, "#logs" do
     end
 
     it "logs to file running.log when :file_run specified and file_path specified" do
-      file = './tmp/example/spec/nice_http/logs_spec.rb.log'
+      file = "./tmp/example/spec/nice_http/logs_spec.rb.log"
       File.delete(file) if File.exist?(file)
       klass.log = :file_run
-      klass.log_path = './tmp/example/'
-      http = klass.new("https://example.com")
+      klass.log_path = "./tmp/example/"
+      http = klass.new(TEST_SERVER_URL)
       http.logger.info "testing XaXDop"
       content = File.read(file)
       expect(content).to match /testing XaXDop/
@@ -97,21 +95,21 @@ RSpec.describe NiceHttp, "#logs" do
       #Dir.glob("./*.log").each { |file| File.delete(file) }
       files_orig = Dir["./nice_http_20*.log"]
       klass.log = :file
-      http = klass.new("https://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.logger.info "testing"
       files_final = Dir["./nice_http_20*.log"]
       files_final.sort!
-      expect(files_final.size-files_orig.size).to eq 1
+      expect(files_final.size - files_orig.size).to eq 1
       content = File.read(files_final[-1])
       expect(content).to match /testing/
-      expect(http.log_file).to eq files_final[-1].gsub('./', "")
+      expect(http.log_file).to eq files_final[-1].gsub("./", "")
     end
 
     it "doesn't create any log file when :no specified" do
       Dir.glob("./lgs/*.log").each { |file| File.delete(file) }
       klass.log = :no
-      klass.log_path = './tmp/example11/'
-      http = klass.new("https://example.com")
+      klass.log_path = "./tmp/example11/"
+      http = klass.new(TEST_SERVER_URL)
       http.logger.info "TESTING NO LOGS"
       files = Dir["./tmp/example11/*.log"]
       expect(files.size).to eq 0
@@ -121,7 +119,7 @@ RSpec.describe NiceHttp, "#logs" do
     it "raises error if log file not possible to be created" do
       #Dir.glob("./*.log").each { |file| File.delete(file) }
       klass.log = "./"
-      klass.new("https://example.com") rescue err = $ERROR_INFO
+      klass.new(TEST_SERVER_URL) rescue err = $ERROR_INFO
       expect(err.class).to eq NiceHttp::InfoMissing
       expect(err.attribute).to eq :log
       expect(err.message).to match /wrong log/i
@@ -129,69 +127,67 @@ RSpec.describe NiceHttp, "#logs" do
 
     it "doesn't create any log file when exception on creating" do
       klass.log = "./tmp/lgs11/"
-      klass.new("https://example.com") rescue err = $ERROR_INFO
+      klass.new(TEST_SERVER_URL) rescue err = $ERROR_INFO
       files = Dir["./tmp/lgs11/*.log"]
       expect(files.size).to eq 0
     end
 
-    it 'logs data to relative path starting by name' do
+    it "logs data to relative path starting by name" do
       #Dir.glob("./spec/nice_http/*.log").each { |file| File.delete(file) }
-      if File.exist?('./spec/nice_http/nice_http_example.log')
-        File.delete('./spec/nice_http/nice_http_example.log')
+      if File.exist?("./spec/nice_http/nice_http_example.log")
+        File.delete("./spec/nice_http/nice_http_example.log")
       end
-      klass.log = 'nice_http_example.log'
-      klass.new("https://example.com")
-      expect(File.exist?('./spec/nice_http/nice_http_example.log')).to eq true
+      klass.log = "nice_http_example.log"
+      klass.new(TEST_SERVER_URL)
+      expect(File.exist?("./spec/nice_http/nice_http_example.log")).to eq true
     end
 
-    it 'logs data to relative path starting by slash' do
+    it "logs data to relative path starting by slash" do
       #Dir.glob("./spec/nice_http/*.log").each { |file| File.delete(file) }
-      klass.log = '/nice_http_example123.log'
+      klass.log = "/nice_http_example123.log"
       File.delete(klass.log) if File.exist?(klass.log)
-      klass.new("https://example.com")
-      expect(File.exist?('./spec/nice_http/nice_http_example123.log')).to eq true
+      klass.new(TEST_SERVER_URL)
+      expect(File.exist?("./spec/nice_http/nice_http_example123.log")).to eq true
     end
 
     it "cannot close a connection that is already closed" do
-      http = klass.new("https://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.close
       http.close
       content = File.read("./nice_http.log")
       expect(content).to match /It was not possible to close the HTTP connection, already closed/
     end
 
-    it 'logs all the headers if log_headers is :all' do
-      http = klass.new("http://example.com")
+    it "logs all the headers if log_headers is :all" do
+      http = klass.new(TEST_SERVER_URL)
       http.log_headers = :all
-      http.headers = {uno: 'abcdefghijklmnopqrstuvwxyz', dos: '2', tres: '00000000001234567890'}
-      http.get('/')
+      http.headers = { uno: "abcdefghijklmnopqrstuvwxyz", dos: "2", tres: "00000000001234567890" }
+      http.get("/")
       content = File.read("./nice_http.log")
       expected = "headers: {uno:abcdefghijklmnopqrstuvwxyz, dos:2, tres:00000000001234567890,"
       expect(content).to match(expected)
     end
 
     it 'doesn\'t log any headers if log_headers is :none' do
-      http = klass.new("http://example.com")
+      http = klass.new(TEST_SERVER_URL)
       http.log_headers = :none
-      http.headers = {uno: 'abcdefghijklmnopqrstuvwxyz', dos: '2', tres: '00000000001234567890'}
-      http.get('/')
+      http.headers = { uno: "abcdefghijklmnopqrstuvwxyz", dos: "2", tres: "00000000001234567890" }
+      http.get("/")
       content = File.read("./nice_http.log")
       expected = "headers: {uno:'', dos:'', tres:'',"
       expect(content).to match(expected)
-      expect(content).to match('No header values since option log_headers is set to :none')      
+      expect(content).to match("No header values since option log_headers is set to :none")
     end
 
-    it 'logs only 10 last chars of headers if log_headers is :partial' do
-      http = klass.new("http://example.com")
+    it "logs only 10 last chars of headers if log_headers is :partial" do
+      http = klass.new(TEST_SERVER_URL)
       http.log_headers = :partial
-      http.headers = {uno: 'abcdefghijklmnopqrstuvwxyz', dos: '2', tres: '00000000001234567890'}
-      http.get('/')
+      http.headers = { uno: "abcdefghijklmnopqrstuvwxyz", dos: "2", tres: "00000000001234567890" }
+      http.get("/")
       content = File.read("./nice_http.log")
       expected = "{uno: ...qrstuvwxyz, dos:2, tres: ...1234567890"
       expect(content).to match(expected)
-      expect(content).to match('Just the last 10 characters on header values since option log_headers is set to :partial')      
+      expect(content).to match("Just the last 10 characters on header values since option log_headers is set to :partial")
     end
-    
-  
-  end  
+  end
 end

--- a/spec/nice_http/methods/delete_spec.rb
+++ b/spec/nice_http/methods/delete_spec.rb
@@ -3,7 +3,7 @@ require "nice_http"
 RSpec.describe NiceHttp, "#delete" do
   before do
     NiceHttp.log_files = Hash.new()
-    @http = NiceHttp.new("https://reqres.in")
+    @http = NiceHttp.new(TEST_SERVER_URL)
   end
 
   it "accepts path as string parameter" do
@@ -12,7 +12,7 @@ RSpec.describe NiceHttp, "#delete" do
   end
 
   it "accepts Hash with key path" do
-    resp = @http.delete({path: "/api/users/2"})
+    resp = @http.delete({ path: "/api/users/2" })
     expect(resp.code).to eq 204
   end
 
@@ -32,26 +32,26 @@ RSpec.describe NiceHttp, "#delete" do
       mock_response: {
         code: 100,
         message: "mock",
-        data: {example: "mock"},
+        data: { example: "mock" },
       },
     }
     resp = @http.delete(request)
     expect(resp.class).to eq Hash
     expect(resp.code).to eq 100
     expect(resp.message).to eq "mock"
-    expect(resp.data.json).to eq ({example: "mock"})
+    expect(resp.data.json).to eq ({ example: "mock" })
   end
 
   it 'doesn\'t redirect when auto_redirect is false and http code is 30x' do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
     http.auto_redirect = false
     req = {
       path: "/exampleRedirect",
-      data: {example: "example"},
+      data: { example: "example" },
     }
     resp = http.delete(req)
-    expect(resp.code).to be_in('300'..'399')
+    expect(resp.code).to be_in("300".."399")
   end
 
   it "detects wrong json when supplying wrong mock_response data" do
@@ -60,7 +60,7 @@ RSpec.describe NiceHttp, "#delete" do
       mock_response: {
         code: 200,
         message: "OK",
-        data: {a: "Android\xAE"},
+        data: { a: "Android\xAE" },
       },
     }
     @http.use_mocks = true
@@ -70,17 +70,15 @@ RSpec.describe NiceHttp, "#delete" do
   end
 
   it "accepts data to be part of the request to send" do
-    resp = @http.delete({path: "/api/users/2", data: [33]})
+    resp = @http.delete({ path: "/api/users/2", data: [33] })
     expect(resp.code).to eq 204
   end
 
   it "set the cookies when required" do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
-    resp = http.delete('/setcookie')
+    resp = http.delete("/setcookie")
     expect(resp.key?(:'set-cookie')).to eq true
     expect(http.cookies["/"].key?("something")).to eq true
   end
-
-
 end

--- a/spec/nice_http/methods/get_spec.rb
+++ b/spec/nice_http/methods/get_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe NiceHttp, "#get" do
   describe "no async" do
     before do
       NiceHttp.log_files = Hash.new()
-      @http = NiceHttp.new("https://reqres.in")
+      @http = NiceHttp.new(TEST_SERVER_URL)
     end
 
     it "accepts path as string parameter" do
@@ -46,36 +46,32 @@ RSpec.describe NiceHttp, "#get" do
     end
 
     it "redirects when auto_redirect is true and http code is 30x" do
-      server = "https://samples.auth0.com/"
-      path = "/authorize?client_id=kbyuFDidLLm280LIwVFiazOqjO3ty8KH&response_type=code"
-
+      server = ENV["HOST_EXAMPLE_SINATRA"]
       http = NiceHttp.new(server)
       http.auto_redirect = true
-      resp = http.get(path)
+      resp = http.get("/exampleRedirect")
 
       expect(resp.code).to eq 200
       expect(resp.message).to eq "OK"
     end
 
     it 'doesn\'t redirect when auto_redirect is false and http code is 30x' do
-      server = "https://samples.auth0.com/"
-      path = "/authorize?client_id=kbyuFDidLLm280LIwVFiazOqjO3ty8KH&response_type=code"
-
+      server = ENV["HOST_EXAMPLE_SINATRA"]
       http = NiceHttp.new(server)
       http.auto_redirect = false
-      resp = http.get(path)
+      resp = http.get("/exampleRedirect")
       expect(resp.code).to eq 302
       expect(resp.message).to eq "Found"
     end
 
     it "handles correctly when http or https is on path" do
-      resp = @http.get "https://reqres.in/api/users?page=2"
+      resp = @http.get "#{TEST_SERVER_URL}/api/users?page=2"
       expect(resp.code).to eq 200
       expect(resp.message).to eq "OK"
     end
 
     it "set the cookies when required" do
-      server = ENV['HOST_EXAMPLE_SINATRA']
+      server = ENV["HOST_EXAMPLE_SINATRA"]
       http = NiceHttp.new(server)
       resp = http.get("/setcookie")
       expect(resp.key?(:'set-cookie')).to eq true
@@ -149,26 +145,26 @@ RSpec.describe NiceHttp, "#get" do
       expect(File.exist?("./tmp/slack-smart-bot.png")).to eq false
     end
   end
-  describe 'async' do
+  describe "async" do
     before :each do
       NiceHttp.log_files = Hash.new()
-      @http = NiceHttp.new(host: ENV['HOST_EXAMPLE_SINATRA'], async_wait_seconds: 10, async_header: 'location',
-                           async_completed: 'percComplete', async_resource: 'resourceName', async_status: 'status')
+      @http = NiceHttp.new(host: ENV["HOST_EXAMPLE_SINATRA"], async_wait_seconds: 10, async_header: "location",
+                           async_completed: "percComplete", async_resource: "resourceName", async_status: "status")
     end
 
-    it 'waits until async operation completed when time < than wait time' do
+    it "waits until async operation completed when time < than wait time" do
       started = Time.now
-      resp = @http.get '/async'
+      resp = @http.get "/async"
       elapsed = Time.now - started
       expect(resp.code).to eq 202
-      expect(resp.data.json(:result)).to include 'this is an async operation'
+      expect(resp.data.json(:result)).to include "this is an async operation"
       operation_id = resp.data.json(:result).scan(/id:\s(\d+)/).join
       resource_id = operation_id.reverse
-      expect(resp.async.status).to eq 'Done'
+      expect(resp.async.status).to eq "Done"
       expect(resp.async.data.json.percComplete).to eq 100
-      expect(resp.async.data.json.status).to eq 'Done'
+      expect(resp.async.data.json.status).to eq "Done"
       expect(resp.async.data.json.resourceName).to eq "/resource/#{resource_id}"
-      expect(resp.async.status).to eq 'Done'
+      expect(resp.async.status).to eq "Done"
       expect(resp.async.resource.data.json.resourceId).to eq resource_id
       expect(elapsed).to be < 10
       expect(resp.async.seconds).to eq 4
@@ -176,85 +172,83 @@ RSpec.describe NiceHttp, "#get" do
 
     it "doesn't wait until async operation completed if time > than wait time" do
       @http.async_wait_seconds = 1
-      resp = @http.get '/async'
+      resp = @http.get "/async"
       expect(resp.code).to eq 202
-      expect(resp.data.json(:result)).to include 'this is an async operation'
+      expect(resp.data.json(:result)).to include "this is an async operation"
       operation_id = resp.data.json(:result).scan(/id:\s(\d+)/).join
       resource_id = operation_id.reverse
-      expect(resp.async.status).to eq 'Ongoing'
+      expect(resp.async.status).to eq "Ongoing"
       expect(resp.async.data.json.percComplete).to eq 25
-      expect(resp.async.data.json.status).to eq 'Ongoing'
+      expect(resp.async.data.json.status).to eq "Ongoing"
       expect(resp.async.data.json.resourceName).to eq "/resource/#{resource_id}"
-      expect(resp.async.status).to eq 'Ongoing'
+      expect(resp.async.status).to eq "Ongoing"
       expect(resp.async.resource.data.json.resourceId).to eq resource_id
       expect(resp.async.seconds).to eq 1
     end
 
     it "doesn't wait for async operation if wait==0" do
       @http.async_wait_seconds = 0
-      resp = @http.get '/async'
+      resp = @http.get "/async"
       expect(resp.code).to eq 202
-      expect(resp.data.json(:result)).to include 'this is an async operation'
+      expect(resp.data.json(:result)).to include "this is an async operation"
       expect(resp.key?(:async)).to eq false
     end
 
     it "doesn't wait if async_header not found" do
-      @http.async_header = 'wrong_header'
-      resp = @http.get '/async'
+      @http.async_header = "wrong_header"
+      resp = @http.get "/async"
       expect(resp.code).to eq 202
-      expect(resp.data.json(:result)).to include 'this is an async operation'
+      expect(resp.data.json(:result)).to include "this is an async operation"
       expect(resp.key?(:async)).to eq false
     end
 
     it "waits until max time if async_completed not found" do
-      @http.async_completed = 'wrong_completed'
+      @http.async_completed = "wrong_completed"
       started = Time.now
-      resp = @http.get '/async'
+      resp = @http.get "/async"
       elapsed = Time.now - started
       operation_id = resp.data.json(:result).scan(/id:\s(\d+)/).join
       resource_id = operation_id.reverse
       expect(resp.code).to eq 202
-      expect(resp.data.json(:result)).to include 'this is an async operation'
-      expect(resp.async.data.json.status).to eq 'Done'
+      expect(resp.data.json(:result)).to include "this is an async operation"
+      expect(resp.async.data.json.status).to eq "Done"
       expect(resp.async.data.json.resourceName).to eq "/resource/#{resource_id}"
-      expect(resp.async.status).to eq 'Done'
+      expect(resp.async.status).to eq "Done"
       expect(resp.async.resource.data.json.resourceId).to eq resource_id
       expect(elapsed).to be >= 10
       expect(resp.async.seconds).to eq 10
     end
 
     it "doesn't return resource if async_resource not found" do
-      @http.async_resource = 'wrong_resource'
+      @http.async_resource = "wrong_resource"
       started = Time.now
-      resp = @http.get '/async'
+      resp = @http.get "/async"
       elapsed = Time.now - started
       operation_id = resp.data.json(:result).scan(/id:\s(\d+)/).join
       resource_id = operation_id.reverse
       expect(resp.code).to eq 202
-      expect(resp.data.json(:result)).to include 'this is an async operation'
-      expect(resp.async.data.json.status).to eq 'Done'
+      expect(resp.data.json(:result)).to include "this is an async operation"
+      expect(resp.async.data.json.status).to eq "Done"
       expect(resp.async.data.json.resourceName).to eq "/resource/#{resource_id}"
-      expect(resp.async.status).to eq 'Done'
+      expect(resp.async.status).to eq "Done"
       expect(resp.async.resource).to eq ({})
       expect(resp.async.seconds).to eq 4
     end
 
     it "doesn't return async_status if async_status not found" do
-      @http.async_status = 'wrong_status'
+      @http.async_status = "wrong_status"
       started = Time.now
-      resp = @http.get '/async'
+      resp = @http.get "/async"
       elapsed = Time.now - started
       operation_id = resp.data.json(:result).scan(/id:\s(\d+)/).join
       resource_id = operation_id.reverse
       expect(resp.code).to eq 202
-      expect(resp.data.json(:result)).to include 'this is an async operation'
-      expect(resp.async.data.json.status).to eq 'Done'
+      expect(resp.data.json(:result)).to include "this is an async operation"
+      expect(resp.async.data.json.status).to eq "Done"
       expect(resp.async.data.json.resourceName).to eq "/resource/#{resource_id}"
       expect(resp.async.resource.data.json.resourceId).to eq resource_id
-      expect(resp.async.status).to eq ''
+      expect(resp.async.status).to eq ""
       expect(resp.async.seconds).to eq 4
     end
-
-
   end
 end

--- a/spec/nice_http/methods/head_spec.rb
+++ b/spec/nice_http/methods/head_spec.rb
@@ -3,7 +3,7 @@ require "nice_http"
 RSpec.describe NiceHttp, "#head" do
   before do
     NiceHttp.log_files = Hash.new()
-    @http = NiceHttp.new("https://reqres.in")
+    @http = NiceHttp.new(TEST_SERVER_URL)
   end
 
   it "accepts path as string parameter" do
@@ -13,7 +13,7 @@ RSpec.describe NiceHttp, "#head" do
   end
 
   it "accepts Hash with key path" do
-    resp = @http.head({path: "/api/users?page=2"})
+    resp = @http.head({ path: "/api/users?page=2" })
     expect(resp.code).to eq 200
     expect(resp.message).to eq "OK"
   end
@@ -53,23 +53,22 @@ RSpec.describe NiceHttp, "#head" do
   end
 
   it 'doesn\'t redirect when auto_redirect is false and http code is 30x' do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
     http.auto_redirect = false
     req = {
       path: "/exampleRedirect",
-      data: {example: "example"},
+      data: { example: "example" },
     }
     resp = http.head(req)
     expect(resp.code.to_i).to be_in(300..399)
   end
 
   it "set the cookies when required" do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
-    resp = http.head('/setcookie')
+    resp = http.head("/setcookie")
     expect(resp.key?(:'set-cookie')).to eq true
     expect(http.cookies["/"].key?("something")).to eq true
   end
-
 end

--- a/spec/nice_http/methods/patch_spec.rb
+++ b/spec/nice_http/methods/patch_spec.rb
@@ -3,13 +3,13 @@ require "nice_http"
 RSpec.describe NiceHttp, "#patch" do
   before do
     NiceHttp.log_files = Hash.new()
-    @http = NiceHttp.new("https://reqres.in")
+    @http = NiceHttp.new(TEST_SERVER_URL)
   end
 
   it "accepts hash including keys :data and :path" do
     resp = @http.patch({
       path: "/api/users/2",
-      data: {name: "morpheus", job: "HR leader"},
+      data: { name: "morpheus", job: "HR leader" },
     })
     expect(resp.code).to eq 200
     expect(resp.data.json(:job)).to eq "HR leader"
@@ -21,7 +21,7 @@ RSpec.describe NiceHttp, "#patch" do
   end
 
   it "returns error in case no path" do
-    resp = @http.patch({data: {name: "morpheus", job: "leader"}})
+    resp = @http.patch({ data: { name: "morpheus", job: "leader" } })
     expect(resp.class).to eq Hash
     expect(resp.fatal_error).to match /no[\w\s]+path/i
     expect(resp.code).to eq nil
@@ -32,7 +32,7 @@ RSpec.describe NiceHttp, "#patch" do
   it "accepts data_examples array in case no data supplied" do
     resp = @http.patch({
       path: "/api/users/2",
-      data_examples: [{name: "doopy", job: "loope"}],
+      data_examples: [{ name: "doopy", job: "loope" }],
     })
     expect(resp.code).to eq 200
     expect(resp.data.json(:name)).to eq "doopy"
@@ -42,39 +42,39 @@ RSpec.describe NiceHttp, "#patch" do
     @http.use_mocks = true
     request = {
       path: "/api/users/2",
-      data: {name: "morpheus", job: "leader"},
+      data: { name: "morpheus", job: "leader" },
       mock_response: {
         code: 100,
         message: "mock",
-        data: {example: "mock"},
+        data: { example: "mock" },
       },
     }
     resp = @http.patch(request)
     expect(resp.class).to eq Hash
     expect(resp.code).to eq 100
     expect(resp.message).to eq "mock"
-    expect(resp.data.json).to eq ({example: "mock"})
+    expect(resp.data.json).to eq ({ example: "mock" })
   end
 
   it "changes :data when supplied :values_for" do
     request = {
       path: "/api/users/2",
-      data: {name: "morpheus", job: "leader"},
+      data: { name: "morpheus", job: "leader" },
     }
 
-    request.values_for = {name: "peter"}
+    request.values_for = { name: "peter" }
     resp = @http.patch(request)
     expect(resp.code).to eq 200
     expect(resp.data.json(:name)).to eq "peter"
   end
 
   it "redirects when auto_redirect is true and http code is 30x" do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
     http.auto_redirect = true
     req = {
       path: "/exampleRedirect",
-      data: {example: "example"},
+      data: { example: "example" },
     }
     resp = http.patch(req)
     expect(resp.code).to eq 200
@@ -82,15 +82,15 @@ RSpec.describe NiceHttp, "#patch" do
   end
 
   it 'doesn\'t redirect when auto_redirect is false and http code is 30x' do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
     http.auto_redirect = false
     req = {
       path: "/exampleRedirect",
-      data: {example: "example"},
+      data: { example: "example" },
     }
     resp = http.patch(req)
-    expect(resp.code).to be_in('300'..'399')
+    expect(resp.code).to be_in("300".."399")
   end
 
   it "detects wrong json when supplying wrong mock_response data" do
@@ -99,7 +99,7 @@ RSpec.describe NiceHttp, "#patch" do
       mock_response: {
         code: 200,
         message: "OK",
-        data: {a: "Android\xAE"},
+        data: { a: "Android\xAE" },
       },
     }
     @http.use_mocks = true
@@ -109,13 +109,12 @@ RSpec.describe NiceHttp, "#patch" do
   end
 
   it "set the cookies when required" do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
-    resp = http.patch('/setcookie')
+    resp = http.patch("/setcookie")
     expect(resp.key?(:'set-cookie')).to eq true
     expect(http.cookies["/"].key?("something")).to eq true
   end
-
 
   #todo: add tests for headers, encoding
 

--- a/spec/nice_http/methods/post_spec.rb
+++ b/spec/nice_http/methods/post_spec.rb
@@ -3,13 +3,13 @@ require "nice_http"
 RSpec.describe NiceHttp, "#post" do
   before do
     NiceHttp.log_files = Hash.new()
-    @http = NiceHttp.new("https://reqres.in")
+    @http = NiceHttp.new(TEST_SERVER_URL)
   end
 
   it "accepts hash including keys :data and :path" do
     resp = @http.post({
       path: "/api/users",
-      data: {name: "morpheus", job: "leader"},
+      data: { name: "morpheus", job: "leader" },
     })
     expect(resp.code).to eq 201
   end
@@ -20,7 +20,7 @@ RSpec.describe NiceHttp, "#post" do
   end
 
   it "returns error in case no path" do
-    resp = @http.post({data: {name: "morpheus", job: "leader"}})
+    resp = @http.post({ data: { name: "morpheus", job: "leader" } })
     expect(resp.class).to eq Hash
     expect(resp.fatal_error).to match /no[\w\s]+path/i
     expect(resp.code).to eq nil
@@ -31,7 +31,7 @@ RSpec.describe NiceHttp, "#post" do
   it "accepts data_examples array in case no data supplied" do
     resp = @http.post({
       path: "/api/users",
-      data_examples: [{name: "doopy", job: "loope"}],
+      data_examples: [{ name: "doopy", job: "loope" }],
     })
     expect(resp.code).to eq 201
     expect(resp.data.json(:name)).to eq "doopy"
@@ -41,27 +41,27 @@ RSpec.describe NiceHttp, "#post" do
     @http.use_mocks = true
     request = {
       path: "/api/users",
-      data: {name: "morpheus", job: "leader"},
+      data: { name: "morpheus", job: "leader" },
       mock_response: {
         code: 100,
         message: "mock",
-        data: {example: "mock"},
+        data: { example: "mock" },
       },
     }
     resp = @http.post(request)
     expect(resp.class).to eq Hash
     expect(resp.code).to eq 100
     expect(resp.message).to eq "mock"
-    expect(resp.data.json).to eq ({example: "mock"})
+    expect(resp.data.json).to eq ({ example: "mock" })
   end
 
   it "changes :data when supplied :values_for" do
     request = {
       path: "/api/users",
-      headers: {"Content-Type": "application/json"},
-      data: {name: "morpheus", job: "leader", lab: {doom: "one", beep: true}, products: [{one: 1, two: 2}, {one: 11, two: 22}]},
+      headers: { "Content-Type": "application/json" },
+      data: { name: "morpheus", job: "leader", lab: { doom: "one", beep: true }, products: [{ one: 1, two: 2 }, { one: 11, two: 22 }] },
     }
-    request.values_for = {name: "peter", doom: "two", one: "uno"}
+    request.values_for = { name: "peter", doom: "two", one: "uno" }
     resp = @http.post(request)
     expect(resp.code).to eq 201
     expect(resp.data.json(:name)).to eq "peter"
@@ -70,12 +70,12 @@ RSpec.describe NiceHttp, "#post" do
   end
 
   it "redirects when auto_redirect is true and http code is 30x" do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
     http.auto_redirect = true
     req = {
       path: "/exampleRedirect",
-      data: {example: "example"},
+      data: { example: "example" },
     }
     resp = http.post(req)
     expect(resp.code).to eq 200
@@ -83,48 +83,48 @@ RSpec.describe NiceHttp, "#post" do
   end
 
   it 'doesn\'t redirect when auto_redirect is false and http code is 30x' do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
     http.auto_redirect = false
     req = {
       path: "/exampleRedirect",
-      data: {example: "example"},
+      data: { example: "example" },
     }
     resp = http.post(req)
-    expect(resp.code).to be_in('300'..'399')
+    expect(resp.code).to be_in("300".."399")
   end
 
   it "accepts all kind of Content-Type" do
     # as symbol
     req = {
       path: "/api/users",
-      headers: {"Content-Type": "application/json"},
+      headers: { "Content-Type": "application/json" },
       data: '{"name": "morpheus","job": "leader"}',
     }
-    @http.headers = {example: lambda {Time.now.to_s}}
+    @http.headers = { example: lambda { Time.now.to_s } }
     # as symbol
     resp = @http.post req
     expect(NiceHttp.last_request).to match /Content-Type:application\/json/
 
-    req.headers = {"content-type": "application/json"}
+    req.headers = { "content-type": "application/json" }
     resp = @http.post req
-    expect(resp.code).to eq '201'
+    expect(resp.code).to eq "201"
 
     # as string
-    req.headers = {"content-type" => "application/json"}
+    req.headers = { "content-type" => "application/json" }
     resp = @http.post req
-    expect(resp.code).to eq '201'
+    expect(resp.code).to eq "201"
 
     # as string
-    req.headers = {"Content-Type" => "application/json"}
+    req.headers = { "Content-Type" => "application/json" }
     resp = @http.post req
-    expect(resp.code).to eq '201'
+    expect(resp.code).to eq "201"
   end
 
   it "implements json data by default if no content type supplied and a hash for data" do
     req = {
       path: "/api/users",
-      data: {name: "morpheus", job: "leader"},
+      data: { name: "morpheus", job: "leader" },
     }
 
     # not supplied content type by default
@@ -144,10 +144,10 @@ RSpec.describe NiceHttp, "#post" do
   it "accepts values as an alias for values_for" do
     request = {
       path: "/api/users",
-      data: {name: "morpheus", job: "leader"},
+      data: { name: "morpheus", job: "leader" },
     }
 
-    request[:values] = {name: "peter"}
+    request[:values] = { name: "peter" }
     resp = @http.post(request)
     expect(resp.code).to eq 201
     expect(resp.data.json(:name)).to eq "peter"
@@ -156,11 +156,11 @@ RSpec.describe NiceHttp, "#post" do
   it "change xml value when supplied values_for" do
     request = {
       path: "/api/users",
-      headers: {"Content-Type": "text/xml"},
+      headers: { "Content-Type": "text/xml" },
       data: "<name>morpheus</name><job>leader</job>",
     }
 
-    request.values_for = {name: "peter"}
+    request.values_for = { name: "peter" }
     resp = @http.post(request)
     expect(NiceHttp.last_request).to match /name>peter/
   end
@@ -168,10 +168,10 @@ RSpec.describe NiceHttp, "#post" do
   it "changes json string values when values_for supplied and json is a string" do
     request = {
       path: "/api/users",
-      headers: {"Content-Type": "application/json"},
+      headers: { "Content-Type": "application/json" },
       data: '{"name": "morpheus","job": "leader"}',
     }
-    request.values_for = {name: "peter"}
+    request.values_for = { name: "peter" }
     resp = @http.post(request)
     expect(NiceHttp.last_request).to match /"name": "peter"/
   end
@@ -179,10 +179,10 @@ RSpec.describe NiceHttp, "#post" do
   it "accepts an array as data" do
     request = {
       path: "/api/users",
-      headers: {"Content-Type": "application/json"},
+      headers: { "Content-Type": "application/json" },
       data: [
-        {name: "morpheus", job: "leader"},
-        {name: "peter", job: "vicepresident"},
+        { name: "morpheus", job: "leader" },
+        { name: "peter", job: "vicepresident" },
       ],
     }
     resp = @http.post(request)
@@ -193,13 +193,13 @@ RSpec.describe NiceHttp, "#post" do
   it "changes all values on array request when values_for" do
     request = {
       path: "/api/users",
-      headers: {"Content-Type": "application/json"},
+      headers: { "Content-Type": "application/json" },
       data: [
-        {name: "morpheus", job: "leader"},
-        {name: "peter", job: "vicepresident"},
+        { name: "morpheus", job: "leader" },
+        { name: "peter", job: "vicepresident" },
       ],
     }
-    request.values_for = {job: "dev"}
+    request.values_for = { job: "dev" }
     resp = @http.post(request)
     expect(resp.code).to eq 201
     expect(resp.data.json(:job)).to eq ["dev", "dev"]
@@ -208,13 +208,13 @@ RSpec.describe NiceHttp, "#post" do
   it "changes all values on array request when values_for is array of hashes" do
     request = {
       path: "/api/users",
-      headers: {"Content-Type": "application/json"},
+      headers: { "Content-Type": "application/json" },
       data: [
-        {name: "morpheus", job: "leader"},
-        {name: "peter", job: "vicepresident"},
+        { name: "morpheus", job: "leader" },
+        { name: "peter", job: "vicepresident" },
       ],
     }
-    request.values_for = [{job: "dev"}, {job: "cleaner"}]
+    request.values_for = [{ job: "dev" }, { job: "cleaner" }]
     resp = @http.post(request)
 
     expect(resp.code).to eq 201
@@ -224,10 +224,10 @@ RSpec.describe NiceHttp, "#post" do
   it "shows wrong format on request when not array of hashes supplied for values_for" do
     request = {
       path: "/api/users",
-      headers: {"Content-Type": "application/json"},
+      headers: { "Content-Type": "application/json" },
       data: [
-        {name: "morpheus", job: "leader"},
-        {name: "peter", job: "vicepresident"},
+        { name: "morpheus", job: "leader" },
+        { name: "peter", job: "vicepresident" },
       ],
     }
     request.values_for = "job"
@@ -239,7 +239,7 @@ RSpec.describe NiceHttp, "#post" do
   it "shows wrong format on request when data is not a string, array or hash" do
     request = {
       path: "/api/users",
-      headers: {"Content-Type": "application/json"},
+      headers: { "Content-Type": "application/json" },
       data: 33,
     }
     resp = @http.post(request)
@@ -250,10 +250,10 @@ RSpec.describe NiceHttp, "#post" do
   it "shows wrong data format for given values_for" do
     request = {
       path: "/api/users",
-      headers: {"Content-Type": "text"},
+      headers: { "Content-Type": "text" },
       data: "example",
     }
-    request.values_for = {dog: 1}
+    request.values_for = { dog: 1 }
     resp = @http.post(request)
     content = File.read("./nice_http.log")
     expect(content).to match /values_for key given without a valid content-type or data for request/
@@ -265,7 +265,7 @@ RSpec.describe NiceHttp, "#post" do
       mock_response: {
         code: 200,
         message: "OK",
-        data: {a: "Android\xAE"},
+        data: { a: "Android\xAE" },
       },
     }
     @http.use_mocks = true
@@ -306,7 +306,7 @@ RSpec.describe NiceHttp, "#post" do
 
   it "logs request and response when debug set to true" do
     File.delete("./nice_http_tmp.log") if File.exist?("./nice_http_tmp.log")
-    @http = NiceHttp.new({host: "https://reqres.in", debug: true, log: "./nice_http_tmp.log"})
+    @http = NiceHttp.new({ host: TEST_SERVER_URL, debug: true, log: "./nice_http_tmp.log" })
 
     request = {
       path: "/api/register",
@@ -323,16 +323,16 @@ RSpec.describe NiceHttp, "#post" do
     expect(content).not_to match /Same as the last request/
   end
 
-  it 'accepts application/x-www-form-urlencoded' do
+  it "accepts application/x-www-form-urlencoded" do
     request = {
-      headers: { 'Content-Type': "application/x-www-form-urlencoded"},
+      headers: { 'Content-Type': "application/x-www-form-urlencoded" },
       path: "/register",
       data: {
         "firstname": "my firstname",
-        "lastname": "my lastname"
-      }
+        "lastname": "my lastname",
+      },
     }
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
     resp = http.post request
     expect(resp.code).to eq 201
@@ -342,9 +342,9 @@ RSpec.describe NiceHttp, "#post" do
   end
 
   it "set the cookies when required" do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
-    resp = http.post('/setcookie')
+    resp = http.post("/setcookie")
     expect(resp.key?(:'set-cookie')).to eq true
     expect(http.cookies["/"].key?("something")).to eq true
   end

--- a/spec/nice_http/methods/put_spec.rb
+++ b/spec/nice_http/methods/put_spec.rb
@@ -3,13 +3,13 @@ require "nice_http"
 RSpec.describe NiceHttp, "#put" do
   before do
     NiceHttp.log_files = Hash.new()
-    @http = NiceHttp.new("https://reqres.in")
+    @http = NiceHttp.new(TEST_SERVER_URL)
   end
 
   it "accepts hash including keys :data and :path" do
     resp = @http.put({
       path: "/api/users/2",
-      data: {name: "morpheus", job: "HR leader"},
+      data: { name: "morpheus", job: "HR leader" },
     })
     expect(resp.code).to eq 200
     expect(resp.data.json(:job)).to eq "HR leader"
@@ -21,7 +21,7 @@ RSpec.describe NiceHttp, "#put" do
   end
 
   it "returns error in case no path" do
-    resp = @http.put({data: {name: "morpheus", job: "leader"}})
+    resp = @http.put({ data: { name: "morpheus", job: "leader" } })
     expect(resp.class).to eq Hash
     expect(resp.fatal_error).to match /no[\w\s]+path/i
     expect(resp.code).to eq nil
@@ -32,7 +32,7 @@ RSpec.describe NiceHttp, "#put" do
   it "accepts data_examples array in case no data supplied" do
     resp = @http.put({
       path: "/api/users/2",
-      data_examples: [{name: "doopy", job: "loope"}],
+      data_examples: [{ name: "doopy", job: "loope" }],
     })
     expect(resp.code).to eq 200
     expect(resp.data.json(:name)).to eq "doopy"
@@ -42,27 +42,27 @@ RSpec.describe NiceHttp, "#put" do
     @http.use_mocks = true
     request = {
       path: "/api/users/2",
-      data: {name: "morpheus", job: "leader"},
+      data: { name: "morpheus", job: "leader" },
       mock_response: {
         code: 100,
         message: "mock",
-        data: {example: "mock"},
+        data: { example: "mock" },
       },
     }
     resp = @http.put(request)
     expect(resp.class).to eq Hash
     expect(resp.code).to eq 100
     expect(resp.message).to eq "mock"
-    expect(resp.data.json).to eq ({example: "mock"})
+    expect(resp.data.json).to eq ({ example: "mock" })
   end
 
   it "changes :data when supplied :values_for" do
     request = {
       path: "/api/users/2",
-      data: {name: "morpheus", job: "leader"},
+      data: { name: "morpheus", job: "leader" },
     }
 
-    request.values_for = {name: "peter"}
+    request.values_for = { name: "peter" }
     resp = @http.put(request)
     expect(resp.code).to eq 200
     expect(resp.data.json(:name)).to eq "peter"
@@ -71,26 +71,25 @@ RSpec.describe NiceHttp, "#put" do
   it "changes :data when supplied nested keys on :values_for" do
     request = {
       path: "/api/users/2",
-      data: {name: "morpheus", job: {position:"leader"}},
+      data: { name: "morpheus", job: { position: "leader" } },
     }
 
-    request.values_for = {'job.position': "worker"}
+    request.values_for = { 'job.position': "worker" }
     resp = @http.put(request)
     expect(resp.code).to eq 200
     expect(resp.data.json(:position)).to eq "worker"
   end
 
-
   it 'doesn\'t redirect when auto_redirect is false and http code is 30x' do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
     http.auto_redirect = false
     req = {
       path: "/exampleRedirect",
-      data: {example: "example"},
+      data: { example: "example" },
     }
     resp = http.put(req)
-    expect(resp.code).to be_in('300'..'399')
+    expect(resp.code).to be_in("300".."399")
   end
 
   it "detects wrong json when supplying wrong mock_response data" do
@@ -99,7 +98,7 @@ RSpec.describe NiceHttp, "#put" do
       mock_response: {
         code: 200,
         message: "OK",
-        data: {a: "Android\xAE"},
+        data: { a: "Android\xAE" },
       },
     }
     @http.use_mocks = true
@@ -108,10 +107,10 @@ RSpec.describe NiceHttp, "#put" do
     expect(content).to match /There was a problem converting to json/
   end
 
-  it 'accepts a json array on first level request' do
+  it "accepts a json array on first level request" do
     request = {
       path: "/api/users",
-      data: [20, 30, 40]
+      data: [20, 30, 40],
     }
     resp = @http.post(request)
     expect(resp.code).to eq 201
@@ -119,13 +118,12 @@ RSpec.describe NiceHttp, "#put" do
   end
 
   it "set the cookies when required" do
-    server = ENV['HOST_EXAMPLE_SINATRA']
+    server = ENV["HOST_EXAMPLE_SINATRA"]
     http = NiceHttp.new(server)
-    resp = http.put('/setcookie')
+    resp = http.put("/setcookie")
     expect(resp.key?(:'set-cookie')).to eq true
     expect(http.cookies["/"].key?("something")).to eq true
   end
-
 
   #todo: add tests for headers, encoding
 

--- a/spec/nice_http/methods/send_request_spec.rb
+++ b/spec/nice_http/methods/send_request_spec.rb
@@ -3,7 +3,7 @@ require "nice_http"
 RSpec.describe NiceHttp, "#send_request" do
   before do
     NiceHttp.log_files = Hash.new()
-    @http = NiceHttp.new("https://reqres.in")
+    @http = NiceHttp.new(TEST_SERVER_URL)
   end
 
   it "returns error in case no method supplied on request hash" do
@@ -15,7 +15,7 @@ RSpec.describe NiceHttp, "#send_request" do
   end
 
   it "returns error in case no path supplied on request hash" do
-    resp = @http.send_request({method: :get})
+    resp = @http.send_request({ method: :get })
     expect(resp.class).to eq Hash
     expect(resp.fatal_error).to include "it needs to be supplied a Request Hash"
     expect(resp.code).to eq nil
@@ -23,7 +23,7 @@ RSpec.describe NiceHttp, "#send_request" do
   end
 
   it "returns error in case wrong method supplied on request hash" do
-    resp = @http.send_request({path: "/", method: :wrong})
+    resp = @http.send_request({ path: "/", method: :wrong })
     expect(resp.class).to eq Hash
     expect(resp.fatal_error).to include "it needs to be supplied a Request Hash"
     expect(resp.code).to eq nil
@@ -31,7 +31,7 @@ RSpec.describe NiceHttp, "#send_request" do
   end
 
   it "returns a good response in case of :get method" do
-    resp = @http.send_request({method: :get, path: "/api/users?page=2"})
+    resp = @http.send_request({ method: :get, path: "/api/users?page=2" })
     expect(resp.class).to eq Hash
     expect(resp.code).to eq 200
     expect(resp.message).to eq "OK"
@@ -80,14 +80,14 @@ RSpec.describe NiceHttp, "#send_request" do
   end
 
   it "returns a good response in case of :delete method" do
-    resp = @http.send_request({method: :delete, path: "/api/users?page=2"})
+    resp = @http.send_request({ method: :delete, path: "/api/users?page=2" })
     expect(resp.class).to eq Hash
     expect(resp.code).to eq 204
     expect(resp.message).to eq "No Content"
   end
 
   it "returns a good response in case of :head method" do
-    resp = @http.send_request({method: :head, path: "/api/users?page=2"})
+    resp = @http.send_request({ method: :head, path: "/api/users?page=2" })
     expect(resp.class).to eq Hash
     expect(resp.code).to eq 200
     expect(resp.message).to eq "OK"
@@ -100,7 +100,7 @@ RSpec.describe NiceHttp, "#send_request" do
       mock_response: {
         code: 200,
         message: "OK",
-        data: {a: "Android\xAE"},
+        data: { a: "Android\xAE" },
       },
     }
     @http.use_mocks = true

--- a/spec/nice_http/nice_http_spec.rb
+++ b/spec/nice_http/nice_http_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe NiceHttp do
       klass.port = 433
       klass.ssl = true
       klass.timeout = 20
-      klass.headers = {uno: "one"}
+      klass.headers = { uno: "one" }
       klass.debug = true
       klass.log = :screen
-      klass.log_path = './tmp/'
+      klass.log_path = "./tmp/"
       klass.proxy_host = "example.com"
       klass.proxy_port = 8080
       klass.last_request = {}
-      klass.request = ''
+      klass.request = ""
       klass.last_response = {}
       klass.request_id = "3344"
       klass.use_mocks = true
@@ -25,10 +25,12 @@ RSpec.describe NiceHttp do
       klass.active = 1
       klass.auto_redirect = false
       klass.log_headers = :none
-      klass.values_for = {one: 1}
+      klass.values_for = { one: 1 }
       klass.create_stats = true
-      klass.stats = {one: 1}
+      klass.stats = { one: 1 }
       klass.capture = true
+      klass.connection_retry_attempts = 10
+      klass.connection_retry_base_delay = 5.0
 
       klass.reset!
 
@@ -39,7 +41,7 @@ RSpec.describe NiceHttp do
       expect(klass.headers).to eq ({})
       expect(klass.debug).to eq false
       expect(klass.log).to eq :fix_file
-      expect(klass.log_path).to eq ''
+      expect(klass.log_path).to eq ""
       expect(klass.proxy_host).to eq nil
       expect(klass.proxy_port).to eq nil
       expect(klass.last_request).to eq nil
@@ -55,6 +57,82 @@ RSpec.describe NiceHttp do
       expect(klass.create_stats).to eq false
       expect(klass.stats[:all][:num_requests]).to eq 0
       expect(klass.capture).to eq false
+      expect(klass.connection_retry_attempts).to eq 3
+      expect(klass.connection_retry_base_delay).to eq 1.0
+    end
+  end
+
+  describe "connection retry on too many open files" do
+    before do
+      klass.host = "example.com"
+      klass.port = 443
+      klass.ssl = true
+      klass.log = :no
+    end
+
+    it "retries and succeeds when start raises EMFILE then succeeds" do
+      start_calls = 0
+      allow(Net::HTTP).to receive(:new).and_wrap_original do |orig, *args, &block|
+        http = orig.call(*args, &block)
+        allow(http).to receive(:start) do
+          start_calls += 1
+          raise Errno::EMFILE if start_calls <= 1
+          nil
+        end
+        http
+      end
+      http = klass.new
+      expect(klass.connections).to include(http)
+      expect(start_calls).to eq 2
+    end
+
+    it "raises after exhausting retries when start always raises EMFILE" do
+      allow(Net::HTTP).to receive(:new).and_wrap_original do |orig, *args, &block|
+        http = orig.call(*args, &block)
+        allow(http).to receive(:start).and_raise(Errno::EMFILE)
+        http
+      end
+      expect { klass.new }.to raise_error(Errno::EMFILE)
+    end
+
+    it "does not retry on non-retryable errors" do
+      allow(Net::HTTP).to receive(:new).and_wrap_original do |orig, *args, &block|
+        http = orig.call(*args, &block)
+        allow(http).to receive(:start).and_raise(Errno::ECONNREFUSED)
+        http
+      end
+      expect { klass.new }.to raise_error(Errno::ECONNREFUSED)
+    end
+
+    it "uses connection_retry_attempts: 1 for no retries" do
+      start_calls = 0
+      allow(Net::HTTP).to receive(:new).and_wrap_original do |orig, *args, &block|
+        http = orig.call(*args, &block)
+        allow(http).to receive(:start).and_wrap_original do |orig_start, *a, &b|
+          start_calls += 1
+          raise Errno::EMFILE
+        end
+        http
+      end
+      expect { klass.new(connection_retry_attempts: 1) }.to raise_error(Errno::EMFILE)
+      expect(start_calls).to eq 1
+    end
+
+    it "uses class-level connection_retry_attempts when set" do
+      klass.connection_retry_attempts = 3
+      start_calls = 0
+      allow(Net::HTTP).to receive(:new).and_wrap_original do |orig, *args, &block|
+        http = orig.call(*args, &block)
+        allow(http).to receive(:start) do
+          start_calls += 1
+          raise Errno::EMFILE if start_calls <= 2
+          nil
+        end
+        http
+      end
+      http = klass.new
+      expect(klass.connections).to include(http)
+      expect(start_calls).to eq 3
     end
   end
 
@@ -103,6 +181,12 @@ RSpec.describe NiceHttp do
       klass.new rescue err = $ERROR_INFO
       expect(err.attribute).to eq :host
       expect(err.message).to match /wrong host/i
+    end
+    it "error message suggests supplying http:// or https:// when host is URL" do
+      klass.host = nil
+      klass.port = 443
+      klass.new rescue err = $ERROR_INFO
+      expect(err.message).to match(/http:\/\//)
     end
   end
 
@@ -156,26 +240,26 @@ RSpec.describe NiceHttp do
       expect(err.attribute).to eq :timeout
       expect(err.message).to match /wrong timeout/i
     end
-    it 'returns fatal error if timeout reached when reading' do
+    it "returns fatal error if timeout reached when reading" do
       klass.timeout = 2
-      http = klass.new("https://reqres.in")
+      http = klass.new(TEST_SERVER_URL)
       resp = http.get("/api/users?delay=3")
       expect(resp.code).to be_nil
       expect(resp.message).to be_nil
-      expect(resp.fatal_error).to eq 'Net::ReadTimeout'
+      expect(resp.fatal_error).to eq "Net::ReadTimeout"
     end
-    it 'returns error if not possible to connect when connecting' do
+    it "returns error if not possible to connect when connecting" do
       klass.timeout = 2
       http = klass.new("https://reqres4s55s.in") rescue err = $ERROR_INFO
       expect(err.message).to match /Failed to open TCP/i
     end
-    it 'returns error if timeout reached when connecting' do
+    it "returns error if timeout reached when connecting" do
       klass.timeout = 2
       http = klass.new("http://example.com:8888") rescue err = $ERROR_INFO
       expect(err.message).to match /(execution expired|Failed to open TCP connection)/i
     end
   end
-  
+
   describe "debug" do
     it "uses the class debug by default" do
       klass.debug = true
@@ -272,7 +356,7 @@ RSpec.describe NiceHttp do
 
   describe "headers" do
     it "uses the class headers by default" do
-      klass.headers = {example: "test"}
+      klass.headers = { example: "test" }
       klass.host = "example.com"
       klass.port = 443
       expect(klass.new.headers).to eq klass.headers
@@ -281,7 +365,16 @@ RSpec.describe NiceHttp do
       klass.port = 443
       klass.host = "example.com"
       klass.headers = {}
-      expect(klass.new(headers: {example: "test"}).headers).to eq ({example: "test"})
+      expect(klass.new(headers: { example: "test" }).headers).to eq ({ example: "test" })
+    end
+    it "uses headers from .generate when hash responds to generate (nice_hash style)" do
+      headers_with_generate = {}
+      headers_with_generate.define_singleton_method(:generate) { { "X-Custom-Header" => "from_generate" } }
+      uri = URI.parse(TEST_SERVER_URL)
+      http = klass.new(host: uri.host, port: uri.port, headers: headers_with_generate)
+      resp = http.get "/echo_headers"
+      expect(resp.code).to eq "200"
+      expect(resp.data).to include("from_generate")
     end
     it 'raises an error when it can\'t figure out the headers' do
       klass.headers = nil
@@ -296,7 +389,7 @@ RSpec.describe NiceHttp do
 
   describe "values_for" do
     it "uses the class values_for by default" do
-      klass.values_for = {example: "test"}
+      klass.values_for = { example: "test" }
       klass.host = "example.com"
       klass.port = 443
       expect(klass.new.values_for).to eq klass.values_for
@@ -305,7 +398,7 @@ RSpec.describe NiceHttp do
       klass.port = 443
       klass.host = "example.com"
       klass.values_for = {}
-      expect(klass.new(values_for: {example: "test"}).values_for).to eq ({example: "test"})
+      expect(klass.new(values_for: { example: "test" }).values_for).to eq ({ example: "test" })
     end
     it 'raises an error when it can\'t figure out the values_for' do
       klass.values_for = nil
@@ -318,12 +411,12 @@ RSpec.describe NiceHttp do
     end
 
     it "changes :data when supplied :values_for on class defaults" do
-      klass.values_for = {name: "peter"}
-      klass.host = "https://reqres.in"
+      klass.values_for = { name: "peter" }
+      klass.host = TEST_SERVER_URL
       http = klass.new
       request = {
         path: "/api/users",
-        data: {name: "morpheus", job: "leader"},
+        data: { name: "morpheus", job: "leader" },
       }
       resp = http.post(request)
       expect(resp.code).to eq 201
@@ -332,11 +425,11 @@ RSpec.describe NiceHttp do
 
     it "changes :data when supplied :values_for on new class instance" do
       klass.values_for = {}
-      klass.host = "https://reqres.in"
-      http = klass.new(values_for: {name: "juan"})
+      klass.host = TEST_SERVER_URL
+      http = klass.new(values_for: { name: "juan" })
       request = {
         path: "/api/users",
-        data: {name: "morpheus", job: "leader"},
+        data: { name: "morpheus", job: "leader" },
       }
       resp = http.post(request)
       expect(resp.code).to eq 201
@@ -345,13 +438,13 @@ RSpec.describe NiceHttp do
 
     it "changes :data when supplied :values_for on request instead of value on class" do
       klass.values_for = {}
-      klass.host = "https://reqres.in"
-      http = klass.new(values_for: {name: "juan"})
+      klass.host = TEST_SERVER_URL
+      http = klass.new(values_for: { name: "juan" })
       request = {
         path: "/api/users",
-        data: {name: "morpheus", job: "leader"},
+        data: { name: "morpheus", job: "leader" },
       }
-      request.values_for = {name: "John"}
+      request.values_for = { name: "John" }
       resp = http.post(request)
       expect(resp.code).to eq 201
       expect(resp.data.json(:name)).to eq "John"
@@ -385,16 +478,16 @@ RSpec.describe NiceHttp do
 
   describe "log_path" do
     it "uses the class log_path by default" do
-      klass.log_path = './tmp/'
+      klass.log_path = "./tmp/"
       klass.host = "example.com"
       klass.port = 443
-      expect(klass.new.log_path).to eq './tmp/'
+      expect(klass.new.log_path).to eq "./tmp/"
     end
     it "can be provided an explicit log_path" do
       klass.port = 443
       klass.host = "example.com"
-      klass.log_path = './tmp/'
-      expect(klass.new(log_path: './tmp/tmp/').log_path).to eq ('./tmp/tmp/')
+      klass.log_path = "./tmp/"
+      expect(klass.new(log_path: "./tmp/tmp/").log_path).to eq ("./tmp/tmp/")
     end
   end
 
@@ -433,7 +526,7 @@ RSpec.describe NiceHttp do
       expect(klass.log).to eq (:fix_file)
     end
     specify "log_path is ''" do
-      expect(klass.log_path).to eq ('')
+      expect(klass.log_path).to eq ("")
     end
     specify "create_stats is false" do
       expect(klass.create_stats).to eq false
@@ -450,31 +543,31 @@ RSpec.describe NiceHttp do
       expect { klass.auto_redirect = false }.to change { klass.auto_redirect }.to(false)
       expect { klass.log_headers = :partial }.to change { klass.log_headers }.to(:partial)
       expect { klass.use_mocks = true }.to change { klass.use_mocks }.to(true)
-      expect { klass.headers = {example: "test"} }.to change { klass.headers }.to({example: "test"})
-      expect { klass.values_for = {example: "test"} }.to change { klass.values_for }.to({example: "test"})
+      expect { klass.headers = { example: "test" } }.to change { klass.headers }.to({ example: "test" })
+      expect { klass.values_for = { example: "test" } }.to change { klass.values_for }.to({ example: "test" })
       expect { klass.log = :screen }.to change { klass.log }.to(:screen)
-      expect { klass.log_path = './tmp/' }.to change { klass.log_path }.to('./tmp/')
+      expect { klass.log_path = "./tmp/" }.to change { klass.log_path }.to("./tmp/")
       expect { klass.create_stats = true }.to change { klass.create_stats }.to(true)
       expect { klass.capture = true }.to change { klass.capture }.to(true)
     end
     specify "I can set many at once with a hash" do
-      expect { klass.defaults = {port: 8888} }.to change { klass.port }.to(8888)
-      expect { klass.defaults = {host: "localhost"} }.to change { klass.host }.to("localhost")
-      expect { klass.defaults = {ssl: true} }.to change { klass.ssl }.to(true)
-      expect { klass.defaults = {timeout: 15} }.to change { klass.timeout }.to(15)
-      expect { klass.defaults = {debug: true} }.to change { klass.debug }.to(true)
-      expect { klass.defaults = {auto_redirect: false} }.to change { klass.auto_redirect }.to(false)
-      expect { klass.defaults = {log_headers: :none} }.to change { klass.log_headers }.to(:none)
-      expect { klass.defaults = {use_mocks: true} }.to change { klass.use_mocks }.to(true)
-      expect { klass.defaults = {headers: {example: "test"}} }.to change { klass.headers }.to({example: "test"})
-      expect { klass.defaults = {values_for: {example: "test"}} }.to change { klass.values_for }.to({example: "test"})
-      expect { klass.defaults = {log: :screen} }.to change { klass.log }.to(:screen)
-      expect { klass.defaults = {log_path: './tmp/'} }.to change { klass.log_path }.to('./tmp/')
-      expect { klass.defaults = {create_stats: true} }.to change { klass.create_stats }.to(true)
-      expect { klass.defaults = {capture: true} }.to change { klass.capture }.to(true)
+      expect { klass.defaults = { port: 8888 } }.to change { klass.port }.to(8888)
+      expect { klass.defaults = { host: "localhost" } }.to change { klass.host }.to("localhost")
+      expect { klass.defaults = { ssl: true } }.to change { klass.ssl }.to(true)
+      expect { klass.defaults = { timeout: 15 } }.to change { klass.timeout }.to(15)
+      expect { klass.defaults = { debug: true } }.to change { klass.debug }.to(true)
+      expect { klass.defaults = { auto_redirect: false } }.to change { klass.auto_redirect }.to(false)
+      expect { klass.defaults = { log_headers: :none } }.to change { klass.log_headers }.to(:none)
+      expect { klass.defaults = { use_mocks: true } }.to change { klass.use_mocks }.to(true)
+      expect { klass.defaults = { headers: { example: "test" } } }.to change { klass.headers }.to({ example: "test" })
+      expect { klass.defaults = { values_for: { example: "test" } } }.to change { klass.values_for }.to({ example: "test" })
+      expect { klass.defaults = { log: :screen } }.to change { klass.log }.to(:screen)
+      expect { klass.defaults = { log_path: "./tmp/" } }.to change { klass.log_path }.to("./tmp/")
+      expect { klass.defaults = { create_stats: true } }.to change { klass.create_stats }.to(true)
+      expect { klass.defaults = { capture: true } }.to change { klass.capture }.to(true)
     end
     specify 'setting many at once doesn\'t override unprovided values' do
-      expect { klass.defaults = {host: "http://whatevz.com"} }.to_not change { klass.port }
+      expect { klass.defaults = { host: "http://whatevz.com" } }.to_not change { klass.port }
     end
   end
 
@@ -499,17 +592,34 @@ RSpec.describe NiceHttp do
       expect(klass.connections.size).to eq 1
       expect(klass.connections[0]).to eq http2
     end
+
+    it "double close does not raise" do
+      klass.host = "https://www.example.com"
+      http = klass.new
+      expect { http.close; http.close }.not_to raise_error
+    end
+  end
+
+  describe "inherited" do
+    it "subclass gets default values from reset!" do
+      subclass = Class.new(NiceHttp)
+      expect(subclass.port).to eq 80
+      expect(subclass.ssl).to eq false
+      expect(subclass.connections).to eq []
+      expect(subclass.async_header).to eq "location"
+    end
   end
 
   describe "proxys" do
     it "starts proxy supplied host and port" do
+      skip "proxy test hits real example.com; use USE_FAKE_API=false to run" if ENV["USE_FAKE_API"] != "false"
       klass.proxy_host = "example.com"
       klass.proxy_port = 80
-      http = klass.new("http://example.com")
+      http = klass.new(TEST_SERVER_URL)
       resp = http.get "/"
       expect(resp.code).to eq 200
 
-      http2 = klass.new("http://www.google.com")
+      http2 = klass.new(TEST_SERVER_URL_2)
       resp = http2.get "/"
       expect(resp.code).to eq 404
     end
@@ -517,16 +627,27 @@ RSpec.describe NiceHttp do
 
   describe "prepaths" do
     it "adds the prepath if supplied" do
-      http = klass.new("https://reqres.in/api")
+      http = klass.new("#{TEST_SERVER_URL}/api")
       resp = http.get "/users?page=2"
       expect(resp.code).to eq 200
     end
   end
 
+  describe "response encoding" do
+    it "receives body from endpoint with non-UTF-8 charset (é in ISO-8859-1)" do
+      http = klass.new(TEST_SERVER_URL)
+      resp = http.get "/encoding_iso8859"
+      expect(resp.code).to eq "200"
+      # Server sends "café": 4 bytes in ISO-8859-1 or 5 in UTF-8 if library converts
+      expect(resp.data.bytes[0, 3]).to eq [99, 97, 102]
+      expect(resp.data.bytes.length).to be_between(4, 5)
+    end
+  end
+
   describe "lambda on headers" do
     it "execute lambdas on headers for every request" do
-      http = klass.new("https://reqres.in/api")
-      req = {path: "/users?page=2", headers: {example: lambda {Time.now.to_s}}}
+      http = klass.new("#{TEST_SERVER_URL}/api")
+      req = { path: "/users?page=2", headers: { example: lambda { Time.now.to_s } } }
       resp = http.get req.generate
       first_request = klass.last_request.scan(/example:([\d\-\s:+]+),/).join
       expect(klass.last_request).to match /example:[\d\-\s:+]+,/
@@ -538,8 +659,8 @@ RSpec.describe NiceHttp do
     end
 
     it "execute lambdas on headers when initializing" do
-      klass.headers = {example: lambda {Time.now.to_s}}
-      http = klass.new("https://reqres.in/api")
+      klass.headers = { example: lambda { Time.now.to_s } }
+      http = klass.new("#{TEST_SERVER_URL}/api")
       resp = http.get "/users?page=2"
       first_request = klass.last_request.scan(/example:([\d\-\s:+]+),/).join
       expect(klass.last_request).to match /example:[\d\-\s:+]+,/
@@ -547,16 +668,15 @@ RSpec.describe NiceHttp do
       resp = http.get "/users?page=2"
       expect(klass.last_request).to match /Same headers as in the previous request/
     end
-
   end
 
   describe "request object" do
     it "accesses request object after sent" do
-      klass.host = "https://reqres.in"
+      klass.host = TEST_SERVER_URL
       http = klass.new
       request = {
         path: "/api/users",
-        data: {name: "peter", job: "leader", city: "london"},
+        data: { name: "peter", job: "leader", city: "london" },
       }
       resp = http.post(request)
       expect(klass.request.path).to eq request.path
@@ -564,44 +684,42 @@ RSpec.describe NiceHttp do
 
       request = {
         path: "/api/users/",
-        data: {name: "petera", job: "slave"},
+        data: { name: "petera", job: "slave" },
       }
       resp = http.post(request)
       expect(klass.request.path).to eq request.path
       expect(klass.request.data.json).to eq request.data
-
     end
 
-    it 'can access the object with lambda' do
-      klass.host = "https://reqres.in"
+    it "can access the object with lambda" do
+      klass.host = TEST_SERVER_URL
       klass.requests = {
         headers: {
-          Referer: lambda { klass.host + klass.request.path }
-        }
+          Referer: lambda { klass.host + klass.request.path },
+        },
       }
       http = klass.new
       request = {
         path: "/api/users",
-        data: {name: "peter", job: "leader", city: "london"},
+        data: { name: "peter", job: "leader", city: "london" },
       }
       resp = http.post(request)
       expect(klass.request.headers[:Referer]).to eq (klass.host + request.path)
     end
-
   end
 
   describe "requests object" do
     it "supplies :headers specified to all requests" do
-      klass.host = "https://reqres.in"
+      klass.host = TEST_SERVER_URL
       klass.requests = {
         headers: {
-          Referer: lambda { klass.host + klass.request.path }
-        }
+          Referer: lambda { klass.host + klass.request.path },
+        },
       }
       http = klass.new
       request = {
         path: "/api/users",
-        data: {name: "peter", job: "leader", city: "london"},
+        data: { name: "peter", job: "leader", city: "london" },
       }
       resp = http.post(request)
       expect(klass.request.headers[:Referer]).to eq (klass.host + request.path)
@@ -613,164 +731,162 @@ RSpec.describe NiceHttp do
     end
 
     it "supplies :path parameters specified to all requests" do
-      klass.host = "https://reqres.in"
-      
-      klass.requests = { path: 'page=2' }
+      klass.host = TEST_SERVER_URL
+
+      klass.requests = { path: "page=2" }
       http = klass.new
       resp = http.get("/api/users")
-      expect(resp.data.json(:page)).to eq '2'
+      expect(resp.data.json(:page)).to eq "2"
 
-      klass.requests = { path: '?page=2' }
+      klass.requests = { path: "?page=2" }
       http = klass.new
       resp = http.get("/api/users")
-      expect(resp.data.json(:page)).to eq '2'      
+      expect(resp.data.json(:page)).to eq "2"
 
-      klass.requests = { path: 'page=2' }
+      klass.requests = { path: "page=2" }
       http = klass.new
       resp = http.get("/api/users?")
-      expect(resp.data.json(:page)).to eq '2'
+      expect(resp.data.json(:page)).to eq "2"
 
-      klass.requests = { path: 'page=2' }
+      klass.requests = { path: "page=2" }
       http = klass.new
       resp = http.get("/api/users?lolo=1")
-      expect(resp.data.json(:page)).to eq '2'
+      expect(resp.data.json(:page)).to eq "2"
 
-      klass.requests = { path: '&page=2'}
+      klass.requests = { path: "&page=2" }
       http = klass.new
       resp = http.get("/api/users?lolo=1")
-      expect(resp.data.json(:page)).to eq '2'
-
+      expect(resp.data.json(:page)).to eq "2"
     end
 
     it "supplies :data specified to all requests" do
-      klass.host = "https://reqres.in"
+      klass.host = TEST_SERVER_URL
       klass.requests = {
         data: {
-          namelambda: lambda { 'petera' },
-          name: 'peter'
-        }
+          namelambda: lambda { "petera" },
+          name: "peter",
+        },
       }
       http = klass.new
       request = {
         path: "/api/users",
-        data: {job: "leader", city: "london"},
+        data: { job: "leader", city: "london" },
       }
       resp = http.post(request)
-      expect(klass.request.data.json.name).to eq 'peter'
-      expect(klass.request.data.json.namelambda).to eq 'petera'
+      expect(klass.request.data.json.name).to eq "peter"
+      expect(klass.request.data.json.namelambda).to eq "petera"
     end
 
-    it 'supplies :data specified to all requests with lambda if not on data' do
-      klass.host = "https://reqres.in"
+    it "supplies :data specified to all requests with lambda if not on data" do
+      klass.host = TEST_SERVER_URL
       klass.requests = {
         data: {
-          namelambda: lambda { 'petera' },
-          namelambdafalse: lambda { 'petera' if false },
-          namelambdatrue: lambda { 'petera' if true },
+          namelambda: lambda { "petera" },
+          namelambdafalse: lambda { "petera" if false },
+          namelambdatrue: lambda { "petera" if true },
           love: {
-            namelambda: lambda { 'petera' },
-            namelambdafalse: lambda { 'petera' if false },
-            namelambdatrue: lambda { 'petera' if true },
+            namelambda: lambda { "petera" },
+            namelambdafalse: lambda { "petera" if false },
+            namelambdatrue: lambda { "petera" if true },
           },
           mars: {
-            namelambdafalse: lambda { 'petera' if false },
+            namelambdafalse: lambda { "petera" if false },
           },
-          name: 'peter'
-        }
+          name: "peter",
+        },
       }
       http = klass.new
       request = {
         path: "/api/users",
-        data: {job: "leader", city: "london"},
+        data: { job: "leader", city: "london" },
       }
       resp = http.post(request)
-      expect(klass.request.data.json.job).to eq 'leader'
-      expect(klass.request.data.json.city).to eq 'london'
-      expect(klass.request.data.json.name).to eq 'peter'
-      expect(klass.request.data.json.namelambda).to eq 'petera'
+      expect(klass.request.data.json.job).to eq "leader"
+      expect(klass.request.data.json.city).to eq "london"
+      expect(klass.request.data.json.name).to eq "peter"
+      expect(klass.request.data.json.namelambda).to eq "petera"
       expect(klass.request.data.json.key?(:namelambdafalse)).to eq false
       expect(klass.request.data.json.key?(:namelambdatrue)).to eq true
-      expect(klass.request.data.json.love.namelambda).to eq 'petera'
+      expect(klass.request.data.json.love.namelambda).to eq "petera"
       expect(klass.request.data.json.love.key?(:namelambdafalse)).to eq false
       expect(klass.request.data.json.love.key?(:namelambdatrue)).to eq true
       expect(klass.request.data.json.key?(:mars)).to eq false
     end
 
-    it 'supplies :data specified to all requests with lambda if on data' do
-      klass.host = "https://reqres.in"
+    it "supplies :data specified to all requests with lambda if on data" do
+      klass.host = TEST_SERVER_URL
       klass.requests = {
         data: {
-          namelambda: lambda { 'petera' },
-          namelambdafalse: lambda { 'petera' if false },
-          namelambdatrue: lambda { 'petera' if true },
+          namelambda: lambda { "petera" },
+          namelambdafalse: lambda { "petera" if false },
+          namelambdatrue: lambda { "petera" if true },
           love: {
-            namelambda: lambda { 'petera' },
-            namelambdafalse: lambda { 'petera' if false },
-            namelambdatrue: lambda { 'petera' if true },
+            namelambda: lambda { "petera" },
+            namelambdafalse: lambda { "petera" if false },
+            namelambdatrue: lambda { "petera" if true },
           },
           mars: {
-            namelambdafalse: lambda { 'petera' if false },
+            namelambdafalse: lambda { "petera" if false },
           },
-          name: 'peter'
-        }
+          name: "peter",
+        },
       }
       http = klass.new
       request = {
         path: "/api/users",
         data: {
-          job: "leader", 
+          job: "leader",
           city: "london",
-          namelambda: 'uno',
-          namelambdafalse: 'dos',
-          namelambdatrue: 'tres',
+          namelambda: "uno",
+          namelambdafalse: "dos",
+          namelambdatrue: "tres",
           love: {
-            namelambda: 'cuatro',
-            namelambdafalse: 'cinco',
-            namelambdatrue: 'seis',
+            namelambda: "cuatro",
+            namelambdafalse: "cinco",
+            namelambdatrue: "seis",
           },
           mars: {
-            namelambdafalse: 'siete',
+            namelambdafalse: "siete",
           },
-          name: 'peter'
+          name: "peter",
         },
       }
       resp = http.post(request)
-      expect(klass.request.data.json.job).to eq 'leader'
-      expect(klass.request.data.json.city).to eq 'london'
-      expect(klass.request.data.json.name).to eq 'peter'
-      expect(klass.request.data.json.namelambda).to eq 'petera'
-      expect(klass.request.data.json.namelambdafalse).to eq 'dos'
-      expect(klass.request.data.json.namelambdatrue).to eq 'petera'
-      expect(klass.request.data.json.love.namelambda).to eq 'petera'
-      expect(klass.request.data.json.love.namelambdafalse).to eq 'cinco'
-      expect(klass.request.data.json.love.namelambdatrue).to eq 'petera'
-      expect(klass.request.data.json.mars.namelambdafalse).to eq 'siete'      
+      expect(klass.request.data.json.job).to eq "leader"
+      expect(klass.request.data.json.city).to eq "london"
+      expect(klass.request.data.json.name).to eq "peter"
+      expect(klass.request.data.json.namelambda).to eq "petera"
+      expect(klass.request.data.json.namelambdafalse).to eq "dos"
+      expect(klass.request.data.json.namelambdatrue).to eq "petera"
+      expect(klass.request.data.json.love.namelambda).to eq "petera"
+      expect(klass.request.data.json.love.namelambdafalse).to eq "cinco"
+      expect(klass.request.data.json.love.namelambdatrue).to eq "petera"
+      expect(klass.request.data.json.mars.namelambdafalse).to eq "siete"
     end
 
     it "supplies :values_for specified to all requests" do
-      klass.host = "https://reqres.in"
+      klass.host = TEST_SERVER_URL
       klass.requests = {
         values_for: {
-          job: lambda { 'teacher' },
-          city: 'madrid'
-        }    
+          job: lambda { "teacher" },
+          city: "madrid",
+        },
       }
       http = klass.new
       request = {
         path: "/api/users",
-        data: {job: "leader", city: "london", name: 'mario'},
+        data: { job: "leader", city: "london", name: "mario" },
       }
       resp = http.post(request)
-      expect(klass.request.data.json.job).to eq 'teacher'
-      expect(klass.request.data.json.city).to eq 'madrid'
-      expect(klass.request.data.json.name).to eq 'mario'
+      expect(klass.request.data.json.job).to eq "teacher"
+      expect(klass.request.data.json.city).to eq "madrid"
+      expect(klass.request.data.json.name).to eq "mario"
     end
-
   end
 
   describe "async" do
     it "async_wait_seconds" do
-      klass.host = "https://reqres.in"
+      klass.host = TEST_SERVER_URL
 
       expect(klass.async_wait_seconds).to eq 0
       http = klass.new
@@ -780,30 +896,30 @@ RSpec.describe NiceHttp do
       http = klass.new
       expect(http.async_wait_seconds).to eq 10
       http = klass.new(async_wait_seconds: 20)
-      expect(http.async_wait_seconds).to eq 20      
+      expect(http.async_wait_seconds).to eq 20
 
-      klass.async_wait_seconds = '10'
+      klass.async_wait_seconds = "10"
       klass.new rescue err = $ERROR_INFO
       expect(err.attribute).to eq :async_wait_seconds
       expect(err.message).to match /wrong async_wait_seconds/i
 
-      klass.new(async_wait_seconds: '20') rescue err = $ERROR_INFO
+      klass.new(async_wait_seconds: "20") rescue err = $ERROR_INFO
       expect(err.attribute).to eq :async_wait_seconds
       expect(err.message).to match /wrong async_wait_seconds/i
     end
 
     it "async_header" do
-      klass.host = "https://reqres.in"
+      klass.host = TEST_SERVER_URL
 
-      expect(klass.async_header).to eq 'location'
+      expect(klass.async_header).to eq "location"
       http = klass.new
-      expect(http.async_header).to eq 'location'
-      klass.async_header = 'location2'
-      expect(klass.async_header).to eq 'location2'
+      expect(http.async_header).to eq "location"
+      klass.async_header = "location2"
+      expect(klass.async_header).to eq "location2"
       http = klass.new
-      expect(http.async_header).to eq 'location2'
-      http = klass.new(async_header: 'location3')
-      expect(http.async_header).to eq 'location3'
+      expect(http.async_header).to eq "location2"
+      http = klass.new(async_header: "location3")
+      expect(http.async_header).to eq "location3"
 
       klass.async_header = 10
       klass.new rescue err = $ERROR_INFO
@@ -816,17 +932,17 @@ RSpec.describe NiceHttp do
     end
 
     it "async_status" do
-      klass.host = "https://reqres.in"
+      klass.host = TEST_SERVER_URL
 
-      expect(klass.async_status).to eq ''
+      expect(klass.async_status).to eq ""
       http = klass.new
-      expect(http.async_status).to eq ''
-      klass.async_status = 'status'
-      expect(klass.async_status).to eq 'status'
+      expect(http.async_status).to eq ""
+      klass.async_status = "status"
+      expect(klass.async_status).to eq "status"
       http = klass.new
-      expect(http.async_status).to eq 'status'
-      http = klass.new(async_status: 'status2')
-      expect(http.async_status).to eq 'status2'
+      expect(http.async_status).to eq "status"
+      http = klass.new(async_status: "status2")
+      expect(http.async_status).to eq "status2"
 
       klass.async_status = 0
       klass.new rescue err = $ERROR_INFO
@@ -838,18 +954,18 @@ RSpec.describe NiceHttp do
       expect(err.message).to match /wrong async_status/i
     end
 
-    it 'async_completed' do
-      klass.host = "https://reqres.in"
+    it "async_completed" do
+      klass.host = TEST_SERVER_URL
 
-      expect(klass.async_completed).to eq ''
+      expect(klass.async_completed).to eq ""
       http = klass.new
-      expect(http.async_completed).to eq ''
-      klass.async_completed = 'completed'
-      expect(klass.async_completed).to eq 'completed'
+      expect(http.async_completed).to eq ""
+      klass.async_completed = "completed"
+      expect(klass.async_completed).to eq "completed"
       http = klass.new
-      expect(http.async_completed).to eq 'completed'
-      http = klass.new(async_completed: 'completed2')
-      expect(http.async_completed).to eq 'completed2'
+      expect(http.async_completed).to eq "completed"
+      http = klass.new(async_completed: "completed2")
+      expect(http.async_completed).to eq "completed2"
 
       klass.async_completed = 0
       klass.new rescue err = $ERROR_INFO
@@ -861,18 +977,18 @@ RSpec.describe NiceHttp do
       expect(err.message).to match /wrong async_completed/i
     end
 
-    it 'async_resource' do
-      klass.host = "https://reqres.in"
+    it "async_resource" do
+      klass.host = TEST_SERVER_URL
 
-      expect(klass.async_resource).to eq ''
+      expect(klass.async_resource).to eq ""
       http = klass.new
-      expect(http.async_resource).to eq ''
-      klass.async_resource = 'resource'
-      expect(klass.async_resource).to eq 'resource'
+      expect(http.async_resource).to eq ""
+      klass.async_resource = "resource"
+      expect(klass.async_resource).to eq "resource"
       http = klass.new
-      expect(http.async_resource).to eq 'resource'
-      http = klass.new(async_resource: 'resource2')
-      expect(http.async_resource).to eq 'resource2'
+      expect(http.async_resource).to eq "resource"
+      http = klass.new(async_resource: "resource2")
+      expect(http.async_resource).to eq "resource2"
 
       klass.async_resource = 0
       klass.new rescue err = $ERROR_INFO
@@ -883,14 +999,12 @@ RSpec.describe NiceHttp do
       expect(err.attribute).to eq :async_resource
       expect(err.message).to match /wrong async_resource/i
     end
-
   end
 
-  it 'returns also body as a copy of data for response' do
-    http = klass.new("https://reqres.in")
+  it "returns also body as a copy of data for response" do
+    http = klass.new(TEST_SERVER_URL)
     resp = http.get "/api/users?page=2"
     expect(resp.key?(:body)).to eq true
     expect(resp.body).to eq resp.data
   end
-
 end

--- a/spec/nice_http/stats_spec.rb
+++ b/spec/nice_http/stats_spec.rb
@@ -1,3 +1,4 @@
+require "fileutils"
 require "nice_http"
 require "English"
 
@@ -9,21 +10,21 @@ RSpec.describe NiceHttp do
       it "counts correctly the number of requests" do
         klass.create_stats = true
         expect(klass.stats[:all][:num_requests]).to eq 0
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
         expect(klass.stats[:all][:num_requests]).to eq 1
-        http2 = klass.new("http://www.google.com")
+        http2 = klass.new(TEST_SERVER_URL_2)
         resp = http2.get "/"
         expect(klass.stats[:all][:num_requests]).to eq 2
       end
       it "counts correctly time_elapsed" do
         klass.create_stats = true
         expect(klass.stats[:all][:time_elapsed][:total]).to eq 0
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
         expect(klass.stats[:all][:time_elapsed][:total]).to eq resp[:time_elapsed]
         prev_time = resp[:time_elapsed]
-        http2 = klass.new("http://www.google.com")
+        http2 = klass.new(TEST_SERVER_URL_2)
         resp = http2.get "/"
         expect(klass.stats[:all][:time_elapsed][:total]).to eq (resp[:time_elapsed] + prev_time)
         expect(klass.stats[:all][:time_elapsed][:maximum]).to be >= klass.stats[:all][:time_elapsed][:minimum]
@@ -32,9 +33,9 @@ RSpec.describe NiceHttp do
       end
       it "creates correctly the http method stats" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
-        http2 = klass.new("http://www.google.com")
+        http2 = klass.new(TEST_SERVER_URL_2)
         resp = http2.post "/"
         expect(klass.stats[:all][:method].keys).to eq (["GET", "POST"])
         expect(klass.stats[:all][:method]["GET"].keys).to eq ([:num_requests, :started, :finished, :real_time_elapsed, :time_elapsed, :response])
@@ -43,9 +44,9 @@ RSpec.describe NiceHttp do
 
       it "creates correctly the http response stats" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
-        http2 = klass.new("http://www.google.com")
+        http2 = klass.new(TEST_SERVER_URL_2)
         resp = http2.post "/"
         expect(klass.stats[:all][:method]["GET"][:response].keys).to eq (["200"])
         expect(klass.stats[:all][:method]["GET"][:response]["200"].keys).to eq ([:num_requests, :started, :finished, :real_time_elapsed, :time_elapsed])
@@ -55,61 +56,61 @@ RSpec.describe NiceHttp do
     describe "path" do
       it "counts correctly the number of requests" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
-        expect(klass.stats[:path]["example.com:80"]["/"][:num_requests]).to eq 1
-        http2 = klass.new("http://www.google.com")
+        expect(klass.stats[:path]["localhost:4567"]["/"][:num_requests]).to eq 1
+        http2 = klass.new(TEST_SERVER_URL_2)
         resp = http2.get "/"
-        expect(klass.stats[:path]["www.google.com:80"]["/"][:num_requests]).to eq 1
+        expect(klass.stats[:path]["localhost:4568"]["/"][:num_requests]).to eq 1
       end
       it "counts correctly time_elapsed" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
-        expect(klass.stats[:path]["example.com:80"]["/"][:time_elapsed][:total]).to eq resp[:time_elapsed]
+        expect(klass.stats[:path]["localhost:4567"]["/"][:time_elapsed][:total]).to eq resp[:time_elapsed]
         prev_time = resp[:time_elapsed]
         resp = http.get "/"
-        expect(klass.stats[:path]["example.com:80"]["/"][:time_elapsed][:total]).to eq (resp[:time_elapsed] + prev_time)
-        expect(klass.stats[:path]["example.com:80"]["/"][:time_elapsed][:maximum]).to be >= klass.stats[:all][:time_elapsed][:minimum]
-        expect(klass.stats[:path]["example.com:80"]["/"][:time_elapsed][:minimum]).to be <= klass.stats[:all][:time_elapsed][:maximum]
-        expect(klass.stats[:path]["example.com:80"]["/"][:time_elapsed][:minimum]).to be_between(klass.stats[:all][:time_elapsed][:minimum], klass.stats[:all][:time_elapsed][:maximum])
+        expect(klass.stats[:path]["localhost:4567"]["/"][:time_elapsed][:total]).to eq (resp[:time_elapsed] + prev_time)
+        expect(klass.stats[:path]["localhost:4567"]["/"][:time_elapsed][:maximum]).to be >= klass.stats[:all][:time_elapsed][:minimum]
+        expect(klass.stats[:path]["localhost:4567"]["/"][:time_elapsed][:minimum]).to be <= klass.stats[:all][:time_elapsed][:maximum]
+        expect(klass.stats[:path]["localhost:4567"]["/"][:time_elapsed][:minimum]).to be_between(klass.stats[:all][:time_elapsed][:minimum], klass.stats[:all][:time_elapsed][:maximum])
       end
       it "creates correctly the http method stats" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
         resp = http.post "/"
-        expect(klass.stats[:path]["example.com:80"]["/"][:method].keys).to eq (["GET", "POST"])
-        expect(klass.stats[:path]["example.com:80"]["/"][:method]["GET"].keys).to eq ([:num_requests, :started, :finished, :real_time_elapsed, :time_elapsed, :response])
-        expect(klass.stats[:path]["example.com:80"]["/"][:method]["GET"][:time_elapsed][:total]).to be > 0
+        expect(klass.stats[:path]["localhost:4567"]["/"][:method].keys).to eq (["GET", "POST"])
+        expect(klass.stats[:path]["localhost:4567"]["/"][:method]["GET"].keys).to eq ([:num_requests, :started, :finished, :real_time_elapsed, :time_elapsed, :response])
+        expect(klass.stats[:path]["localhost:4567"]["/"][:method]["GET"][:time_elapsed][:total]).to be > 0
       end
 
       it "creates correctly the http response stats" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
         resp = http.post "/"
-        expect(klass.stats[:path]["example.com:80"]["/"][:method]["GET"][:response].keys).to eq (["200"])
-        expect(klass.stats[:path]["example.com:80"]["/"][:method]["GET"][:response]["200"].keys).to eq ([:num_requests, :started, :finished, :real_time_elapsed, :time_elapsed])
-        expect(klass.stats[:path]["example.com:80"]["/"][:method]["GET"][:response]["200"][:time_elapsed][:total]).to be > 0
+        expect(klass.stats[:path]["localhost:4567"]["/"][:method]["GET"][:response].keys).to eq (["200"])
+        expect(klass.stats[:path]["localhost:4567"]["/"][:method]["GET"][:response]["200"].keys).to eq ([:num_requests, :started, :finished, :real_time_elapsed, :time_elapsed])
+        expect(klass.stats[:path]["localhost:4567"]["/"][:method]["GET"][:response]["200"][:time_elapsed][:total]).to be > 0
       end
     end
     describe "name" do
       it "counts correctly the number of requests" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
-        resp = http.get({path: "/", name: "exam_name"})
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get({ path: "/", name: "exam_name" })
         expect(klass.stats[:name]["exam_name"][:num_requests]).to eq 1
-        resp = http.get({path: "/", name: "exam_name"})
+        resp = http.get({ path: "/", name: "exam_name" })
         expect(klass.stats[:name]["exam_name"][:num_requests]).to eq 2
       end
       it "counts correctly time_elapsed" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
-        resp = http.get({path: "/", name: "exam_name"})
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get({ path: "/", name: "exam_name" })
         expect(klass.stats[:name]["exam_name"][:time_elapsed][:total]).to eq resp[:time_elapsed]
         prev_time = resp[:time_elapsed]
-        resp = http.get({path: "/", name: "exam_name"})
+        resp = http.get({ path: "/", name: "exam_name" })
         expect(klass.stats[:name]["exam_name"][:time_elapsed][:total]).to eq (resp[:time_elapsed] + prev_time)
         expect(klass.stats[:name]["exam_name"][:time_elapsed][:maximum]).to be >= klass.stats[:all][:time_elapsed][:minimum]
         expect(klass.stats[:name]["exam_name"][:time_elapsed][:minimum]).to be <= klass.stats[:all][:time_elapsed][:maximum]
@@ -117,9 +118,9 @@ RSpec.describe NiceHttp do
       end
       it "creates correctly the http method stats" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
-        resp = http.get({path: "/", name: "exam_name"})
-        resp = http.post({path: "/", name: "exam_name"})
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get({ path: "/", name: "exam_name" })
+        resp = http.post({ path: "/", name: "exam_name" })
         expect(klass.stats[:name]["exam_name"][:method].keys).to eq (["GET", "POST"])
         expect(klass.stats[:name]["exam_name"][:method]["GET"].keys).to eq ([:num_requests, :started, :finished, :real_time_elapsed, :time_elapsed, :response])
         expect(klass.stats[:name]["exam_name"][:method]["GET"][:time_elapsed][:total]).to be > 0
@@ -127,9 +128,9 @@ RSpec.describe NiceHttp do
 
       it "creates correctly the http response stats" do
         klass.create_stats = true
-        http = klass.new("http://example.com")
-        resp = http.get({path: "/", name: "exam_name"})
-        resp = http.post({path: "/", name: "exam_name"})
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get({ path: "/", name: "exam_name" })
+        resp = http.post({ path: "/", name: "exam_name" })
         expect(klass.stats[:name]["exam_name"][:method]["GET"][:response].keys).to eq (["200"])
         expect(klass.stats[:name]["exam_name"][:method]["GET"][:response]["200"].keys).to eq ([:num_requests, :started, :finished, :real_time_elapsed, :time_elapsed])
         expect(klass.stats[:name]["exam_name"][:method]["GET"][:response]["200"][:time_elapsed][:total]).to be > 0
@@ -140,22 +141,22 @@ RSpec.describe NiceHttp do
       it "counts correctly the number of records" do
         klass.create_stats = true
         started = Time.now
-        http = klass.new("http://example.com")
-        resp = http.get({path: "/", name: "exam_name"})
-        resp = http.get({path: "/", name: "exam_name"})
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get({ path: "/", name: "exam_name" })
+        resp = http.get({ path: "/", name: "exam_name" })
         klass.add_stats(:example, :correct, started, Time.now)
         expect(klass.stats[:specific][:example][:num]).to eq 1
         expect(klass.stats[:specific][:example][:correct][:num]).to eq 1
         started = Time.now
-        resp = http.get({path: "/", name: "exam_name"})
-        resp = http.get({path: "/", name: "exam_name"})
+        resp = http.get({ path: "/", name: "exam_name" })
+        resp = http.get({ path: "/", name: "exam_name" })
         klass.add_stats(:example, :correct, started, Time.now)
         expect(klass.stats[:specific][:example][:num]).to eq 2
         expect(klass.stats[:specific][:example][:correct][:num]).to eq 2
         started = Time.now
-        http = klass.new("http://example.com")
-        resp = http.get({path: "/", name: "exam_name"})
-        resp = http.get({path: "/", name: "exam_name"})
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get({ path: "/", name: "exam_name" })
+        resp = http.get({ path: "/", name: "exam_name" })
         klass.add_stats(:example, :correct, started, Time.now)
         expect(klass.stats[:specific][:example][:num]).to eq 3
         expect(klass.stats[:specific][:example][:correct][:num]).to eq 3
@@ -163,20 +164,20 @@ RSpec.describe NiceHttp do
       it "counts correctly time_elapsed" do
         klass.create_stats = true
         started = Time.now
-        http = klass.new("http://example.com")
-        resp = http.get({path: "/", name: "exam_name"})
-        resp = http.get({path: "/", name: "exam_name"})
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get({ path: "/", name: "exam_name" })
+        resp = http.get({ path: "/", name: "exam_name" })
         finished = Time.now
         klass.add_stats(:example, :correct, started, finished)
-        expect(klass.stats[:specific][:example][:time_elapsed][:total]).to eq (finished-started)
-        expect(klass.stats[:specific][:example][:correct][:time_elapsed][:total]).to eq (finished-started)
+        expect(klass.stats[:specific][:example][:time_elapsed][:total]).to eq (finished - started)
+        expect(klass.stats[:specific][:example][:correct][:time_elapsed][:total]).to eq (finished - started)
       end
       it "creates correctly the hash" do
         klass.create_stats = true
         started = Time.now
-        http = klass.new("http://example.com")
-        resp = http.get({path: "/", name: "exam_name"})
-        resp = http.post({path: "/", name: "exam_name"})
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get({ path: "/", name: "exam_name" })
+        resp = http.post({ path: "/", name: "exam_name" })
         klass.add_stats(:example, :correct, started, Time.now)
         expect(klass.stats[:specific][:example].keys).to eq ([:num, :started, :finished, :real_time_elapsed, :time_elapsed, :correct])
         expect(klass.stats[:specific][:example][:time_elapsed].keys).to eq ([:total, :maximum, :minimum, :average])
@@ -186,9 +187,9 @@ RSpec.describe NiceHttp do
       it "creates correctly the hash with max and min and items" do
         klass.create_stats = true
         started = Time.now
-        http = klass.new("http://example.com")
-        resp = http.get({path: "/", name: "exam_name"})
-        resp = http.post({path: "/", name: "exam_name"})
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get({ path: "/", name: "exam_name" })
+        resp = http.post({ path: "/", name: "exam_name" })
         klass.add_stats(:example, :correct, started, Time.now, "example")
         expect(klass.stats[:specific][:example].keys).to eq ([:num, :started, :finished, :real_time_elapsed, :time_elapsed, :correct])
         expect(klass.stats[:specific][:example][:time_elapsed].keys).to eq ([:total, :maximum, :minimum, :average, :item_maximum, :item_minimum])
@@ -197,59 +198,83 @@ RSpec.describe NiceHttp do
       end
     end
     describe "save_stats" do
-      it 'generates the files when no file_name supplied' do
+      it "generates the files when no file_name supplied" do
         klass.create_stats = true
-        klass.log = './nice_http_tmp.log'
+        klass.log = "./nice_http_tmp.log"
         #File.delete(klass.log) if File.exist?(klass.log)
         #File.delete('./nice_http_tmp_stats_all.yaml') if File.exist?('./nice_http_tmp_stats_all.yaml')
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
         klass.save_stats()
-        expect(File.exist?('./nice_http_tmp_stats_all.yaml')).to eq true
+        expect(File.exist?("./nice_http_tmp_stats_all.yaml")).to eq true
       end
 
-      it 'generates the files when file_name supplied and extension .yaml' do
+      it "generates the files when file_name supplied and extension .yaml" do
         klass.create_stats = true
-        File.delete('./nice_http_tmp_stats_all.yaml') if File.exist?('./nice_http_tmp_stats_all.yaml')
-        http = klass.new("http://example.com")
+        File.delete("./nice_http_tmp_stats_all.yaml") if File.exist?("./nice_http_tmp_stats_all.yaml")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
-        klass.save_stats('./nice_http_tmp.yaml')
-        expect(File.exist?('./nice_http_tmp_stats_all.yaml')).to eq true
+        klass.save_stats("./nice_http_tmp.yaml")
+        expect(File.exist?("./nice_http_tmp_stats_all.yaml")).to eq true
       end
 
-      it 'generates the files when file_name supplied and extension .json' do
+      it "generates the files when file_name supplied and extension .json" do
         klass.create_stats = true
-        File.delete('./nice_http_tmp_stats_all.json') if File.exist?('./nice_http_tmp_stats_all.json')
-        http = klass.new("http://example.com")
+        File.delete("./nice_http_tmp_stats_all.json") if File.exist?("./nice_http_tmp_stats_all.json")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
-        klass.save_stats('./nice_http_tmp.json')
-        expect(File.exist?('./nice_http_tmp_stats_all.json')).to eq true
+        klass.save_stats("./nice_http_tmp.json")
+        expect(File.exist?("./nice_http_tmp_stats_all.json")).to eq true
       end
 
-      it 'generates the stats files when log_path specified and :fix_file' do
-        file = './tmp/logs/nice_http_stats_all.yaml'
+      it "generates the stats files when log_path specified and :fix_file" do
+        file = "./tmp/logs/nice_http_stats_all.yaml"
         klass.create_stats = true
-        klass.log_path = './tmp/logs/'
+        klass.log_path = "./tmp/logs/"
         klass.log = :fix_file
         File.delete(file) if File.exist?(file)
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
         klass.save_stats()
         expect(File.exist?(file)).to eq true
       end
 
-      it 'generates the stats files when log_path specified and :file_run' do
-        file = './tmp/logs/nice_http_stats_all.yaml'
+      it "generates the stats files when log_path specified and :file_run" do
+        file = "./tmp/logs/nice_http_stats_all.yaml"
         klass.create_stats = true
-        klass.log_path = './tmp/logs/'
+        klass.log_path = "./tmp/logs/"
         klass.log = :file_run
         File.delete(file) if File.exist?(file)
-        http = klass.new("http://example.com")
+        http = klass.new(TEST_SERVER_URL)
         resp = http.get "/"
         klass.save_stats()
         expect(File.exist?(file)).to eq true
       end
 
+      it "creates directory when it does not exist" do
+        dir = "./tmp/save_stats_nested_#{Time.now.to_i}"
+        file = "#{dir}/stats.yaml"
+        klass.create_stats = true
+        FileUtils.rm_rf(dir) if File.exist?(dir)
+        http = klass.new(TEST_SERVER_URL)
+        resp = http.get "/"
+        klass.save_stats(file)
+        expect(File.directory?(dir)).to eq true
+        expect(File.exist?("#{dir}/stats_stats_all.yaml")).to eq true
+        FileUtils.rm_rf(dir)
+      end
+    end
+  end
+
+  describe "add_stats (without HTTP)" do
+    it "updates stats[:specific] when called in isolation" do
+      klass.reset!
+      started = Time.now - 1
+      finished = Time.now
+      klass.add_stats(:solo_name, :solo_state, started, finished)
+      expect(klass.stats[:specific][:solo_name][:num]).to eq 1
+      expect(klass.stats[:specific][:solo_name][:solo_state][:num]).to eq 1
+      expect(klass.stats[:specific][:solo_name][:time_elapsed][:total]).to be >= 1
     end
   end
 end

--- a/spec/nice_http/utils/nice_http_utils_spec.rb
+++ b/spec/nice_http/utils/nice_http_utils_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe NiceHttp, "#utils" do
     expect(val).to eq nil
   end
 
+  it "returns nil when xml_string is nil" do
+    val = NiceHttpUtils.get_value_xml_tag("One", nil)
+    expect(val).to eq nil
+  end
+
   it "sets the value for the xml tag supplied" do
     xml = "<Example><One>Uno</One></Example>"
     val = NiceHttpUtils.set_value_xml_tag("One", xml, "Bob")

--- a/spec/nice_http/validate_response_spec.rb
+++ b/spec/nice_http/validate_response_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "ostruct"
+require "nice_http"
+
+RSpec.describe NiceHttp do
+  describe ".validate_response" do
+    it "returns ok: true when response structure matches expected" do
+      resp = { data: '{"name":"Alice","id":1}' }
+      expected = { name: "xxx", id: 1 }
+      result = described_class.validate_response(resp, expected)
+      expect(result[:ok]).to be true
+      expect(result).not_to have_key(:diff)
+    end
+
+    it "returns ok: false when response structure does not match" do
+      resp = { data: '{"name":"Alice"}' }
+      expected = { name: "xxx", id: 1 }
+      result = described_class.validate_response(resp, expected)
+      expect(result[:ok]).to be false
+    end
+
+    it "includes diff when include_diff: true and structure does not match" do
+      resp = { data: '{"name":"Alice"}' }
+      expected = { name: "xxx", id: 1 }
+      result = described_class.validate_response(resp, expected, include_diff: true)
+      expect(result[:ok]).to be false
+      expect(result[:diff]).to be_a(Hash)
+    end
+
+    it "accepts response with method-style data access" do
+      resp = OpenStruct.new(data: '{"user":"test"}')
+      expected = { user: "xxx" }
+      result = described_class.validate_response(resp, expected)
+      expect(result[:ok]).to be true
+    end
+
+    it "returns error when data is not valid JSON" do
+      resp = { data: "not json {" }
+      expected = {}
+      result = described_class.validate_response(resp, expected)
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("not valid JSON")
+    end
+
+    it "returns error when data is missing" do
+      resp = {}
+      expected = {}
+      result = described_class.validate_response(resp, expected)
+      expect(result[:ok]).to be false
+      expect(result[:error]).to be_present
+    end
+
+    it "accepts nested expected structure" do
+      resp = { data: '{"user":{"name":"Bob","age":30}}' }
+      expected = { user: { name: "xxx", age: 1 } }
+      result = described_class.validate_response(resp, expected)
+      expect(result[:ok]).to be true
+    end
+
+    it "accepts response with data as Hash (no JSON string)" do
+      resp = { data: { user: "test", id: 1 } }
+      expected = { user: "xxx", id: 1 }
+      result = described_class.validate_response(resp, expected)
+      expect(result[:ok]).to be true
+    end
+
+    it "accepts expected_structure as Array" do
+      resp = { data: '[{"a":1},{"a":2}]' }
+      expected = [{ a: 1 }]
+      result = described_class.validate_response(resp, expected)
+      expect(result[:ok]).to be true
+    end
+
+    it "does not include diff when ok is true and include_diff: true" do
+      resp = { data: '{"name":"Alice","id":1}' }
+      expected = { name: "xxx", id: 1 }
+      result = described_class.validate_response(resp, expected, include_diff: true)
+      expect(result[:ok]).to be true
+      expect(result).not_to have_key(:diff)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,8 @@
-#https://examplesinatra--tcblues.repl.co/
-#https://exampleSinatra.tcblues.repl.co
-#Go to replit, start the project, and click on DEV at the url bar to get the temporary url
-ENV['HOST_EXAMPLE_SINATRA'] ||= "https://d742ccba-72a2-4d5c-99d8-767f27020871-00-11gu5zl32n4e9.kirk.replit.dev/"
+# Start local fake API server(s) in-process and set HOST_EXAMPLE_SINATRA / TEST_SERVER_URL (set USE_FAKE_API=false to use external hosts)
+require_relative "support/server" if File.exist?(File.join(__dir__, "support", "server.rb"))
+ENV["HOST_EXAMPLE_SINATRA"] ||= "http://localhost:4567"
+TEST_SERVER_URL = ENV["TEST_SERVER_URL"] || "http://localhost:4567" unless defined?(TEST_SERVER_URL)
+TEST_SERVER_URL_2 = ENV["TEST_SERVER_URL_2"] || "http://localhost:4568" unless defined?(TEST_SERVER_URL_2)
 
 require "coveralls"
 Coveralls.wear!

--- a/spec/support/fake_api.rb
+++ b/spec/support/fake_api.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+# Fake API server for nice_http specs (reqres.in-style + async + redirects + set-cookie).
+# Loaded by spec/support/server.rb for in-process use, or run standalone: ruby spec/support/fake_api.rb [port]
+require "sinatra/base"
+require "json"
+require "uri"
+
+class FakeApi < Sinatra::Base
+  set :port, (ENV["FAKE_API_PORT"] || ARGV[0] || 4567).to_i
+
+  # In-memory state for async operation polling
+  OPERATION_POLLS = Hash.new(0)
+
+  get "/" do
+    content_type "text/plain"
+    "OK"
+  end
+
+  # Echo a request header for testing headers.generate (e.g. X-Custom-Header)
+  get "/echo_headers" do
+    content_type "application/json"
+    { "X-Custom-Header" => request.env["HTTP_X_CUSTOM_HEADER"] }.to_json
+  end
+
+  # Response with non-UTF-8 charset for encoding conversion tests (é in ISO-8859-1)
+  get "/encoding_iso8859" do
+    content_type "text/plain; charset=ISO-8859-1"
+    "caf\xE9".dup.force_encoding(Encoding::ISO_8859_1)
+  end
+
+  post "/" do
+    content_type "text/plain"
+    status 200
+    "OK"
+  end
+
+  # --- reqres.in-style API ---
+  get "/api/users" do
+    delay = params["delay"].to_i
+    sleep(delay) if delay > 0
+    content_type "application/json"
+    {
+      page: params["page"] || 1,
+      per_page: 6,
+      total: 12,
+      total_pages: 2,
+      data: [
+        { id: 1, first_name: "George", last_name: "Bluth", avatar: "https://example.com/1.jpg" },
+        { id: 2, first_name: "Janet", last_name: "Weaver", avatar: "https://example.com/2.jpg" },
+      ],
+    }.to_json
+  end
+
+  get "/api/users/2" do
+    content_type "application/json"
+    {
+      data: {
+        id: 2,
+        first_name: "Janet",
+        last_name: "Weaver",
+        avatar: "https://example.com/2.jpg",
+      },
+    }.to_json
+  end
+
+  post "/api/users" do
+    content_type "application/json"
+    status 201
+    body = request.body.read
+    parsed = begin
+        body.empty? ? {} : JSON.parse(body)
+      rescue JSON::ParserError
+        {}
+      end
+    if parsed.is_a?(Array)
+      response = parsed
+    else
+      response = parsed.transform_keys(&:to_sym).merge(
+        id: "999",
+        createdAt: Time.now.utc.iso8601(3),
+      )
+    end
+    response.to_json
+  end
+
+  put "/api/users/2" do
+    content_type "application/json"
+    body = request.body.read
+    parsed = begin
+        body.empty? ? {} : JSON.parse(body)
+      rescue JSON::ParserError
+        {}
+      end
+    (parsed.transform_keys(&:to_sym).merge(id: "2", updatedAt: Time.now.utc.iso8601(3))).to_json
+  end
+
+  patch "/api/users/2" do
+    content_type "application/json"
+    body = request.body.read
+    parsed = begin
+        body.empty? ? {} : JSON.parse(body)
+      rescue JSON::ParserError
+        {}
+      end
+    (parsed.transform_keys(&:to_sym).merge(id: "2", updatedAt: Time.now.utc.iso8601(3))).to_json
+  end
+
+  delete "/api/users/2" do
+    status 204
+    body ""
+  end
+
+  delete "/api/users" do
+    status 204
+    body ""
+  end
+
+  post "/api/register" do
+    content_type "application/json"
+    status 200
+    { id: 1, token: "QpwL5tke4Pnpja7X4" }.to_json
+  end
+
+  # --- set-cookie ---
+  %w[get post put patch delete head].each do |meth|
+    send(meth, "/setcookie") do
+      headers["Set-Cookie"] = "something=value; path=/"
+      content_type "text/plain"
+      "OK"
+    end
+  end
+
+  # --- redirect (302) ---
+  # NiceHttp strips "scheme://host" (no port) from Location, so use "http://host/path" (no port).
+  redirect_302 = proc do
+    status 302
+    headers["Location"] = "http://#{request.host}/redirect_target"
+    content_type "text/plain"
+    ""
+  end
+  get "/exampleRedirect", &redirect_302
+  post "/exampleRedirect", &redirect_302
+  put "/exampleRedirect", &redirect_302
+  patch "/exampleRedirect", &redirect_302
+  delete "/exampleRedirect", &redirect_302
+  head "/exampleRedirect", &redirect_302
+
+  %w[get post put patch delete head].each do |meth|
+    send(meth, "/redirect_target") do
+      content_type "text/plain"
+      status 200
+      "OK"
+    end
+  end
+
+  # --- form-urlencoded (post /register returns 201 and body with decoded params) ---
+  post "/register" do
+    content_type "text/plain"
+    status 201
+    body_str = request.body.read
+    # Echo back decoded form so "my firstname" appears in response
+    decoded = URI.decode_www_form(body_str).to_h
+    decoded.map { |k, v| "#{k}=#{v}" }.join("&")
+  end
+
+  # --- async (202 + polling + resource) ---
+  get "/async" do
+    operation_id = rand(100..999).to_s
+    resource_id = operation_id.reverse
+    OPERATION_POLLS[operation_id] = 0
+    base = "#{request.scheme}://#{request.host}:#{request.port}"
+    headers["Location"] = "#{base}/operation/#{operation_id}"
+    content_type "application/json"
+    status 202
+    { result: "this is an async operation id: #{operation_id}" }.to_json
+  end
+
+  get "/operation/:id" do
+    id = params["id"]
+    OPERATION_POLLS[id] += 1
+    poll = OPERATION_POLLS[id]
+    resource_id = id.reverse
+    if poll >= 5 # 4 "Ongoing" polls then Done so resp.async.seconds == 4
+      status_json = "Done"
+      perc = 100
+    else
+      status_json = "Ongoing"
+      perc = 25
+    end
+    content_type "application/json"
+    {
+      percComplete: perc,
+      resourceName: "/resource/#{resource_id}",
+      status: status_json,
+      operationId: id,
+    }.to_json
+  end
+
+  get "/resource/:id" do
+    content_type "application/json"
+    { resourceId: params["id"], lolo: "lala" }.to_json
+  end
+end
+
+FakeApi.run! if __FILE__ == $PROGRAM_NAME

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Start fake API server(s) in-process (same Ruby as rspec). No subprocess or bundle exec.
+# Set USE_FAKE_API=false to use external hosts (reqres.in, etc.).
+
+require "socket"
+
+def port_open?(host, port)
+  TCPSocket.new(host, port).close
+  true
+rescue Errno::ECONNREFUSED, Errno::EADDRINUSE
+  false
+end
+
+def wait_for_server(host, port, timeout: 10)
+  started = Time.now
+  until port_open?(host, port)
+    raise "Server on #{host}:#{port} did not start in #{timeout}s" if Time.now - started > timeout
+    sleep 0.1
+  end
+end
+
+TEST_SERVER_PORT = (ENV["TEST_SERVER_PORT"] || 4567).to_i
+TEST_SERVER_PORT_2 = (ENV["TEST_SERVER_PORT_2"] || 4568).to_i
+TEST_SERVER_HOST = "localhost"
+TEST_SERVER_URL = "http://#{TEST_SERVER_HOST}:#{TEST_SERVER_PORT}"
+TEST_SERVER_URL_2 = "http://#{TEST_SERVER_HOST}:#{TEST_SERVER_PORT_2}"
+
+if ENV["USE_FAKE_API"] != "false"
+  begin
+    require "sinatra/base"
+    require "webrick"
+    require_relative "fake_api"
+
+    # Run two servers in threads (stats_spec needs two host:port).
+    # Use a subclass per port so Sinatra doesn't reuse the same port.
+    [TEST_SERVER_PORT, TEST_SERVER_PORT_2].each do |port|
+      Thread.new do
+        app = Class.new(FakeApi) { set :port, port }
+        app.run!(
+          server: "webrick",
+          Logger: WEBrick::Log.new(File::NULL),
+          AccessLog: [],
+        )
+      end
+    end
+
+    wait_for_server(TEST_SERVER_HOST, TEST_SERVER_PORT)
+    wait_for_server(TEST_SERVER_HOST, TEST_SERVER_PORT_2)
+
+    ENV["HOST_EXAMPLE_SINATRA"] = TEST_SERVER_URL
+    ENV["TEST_SERVER_URL"] = TEST_SERVER_URL
+    ENV["TEST_SERVER_URL_2"] = TEST_SERVER_URL_2
+    ENV["TEST_SERVER_PORT"] = TEST_SERVER_PORT.to_s
+    ENV["TEST_SERVER_PORT_2"] = TEST_SERVER_PORT_2.to_s
+  rescue LoadError => e
+    warn "Fake API skipped (Sinatra not available: #{e.message}); set USE_FAKE_API=false to use external hosts."
+    ENV["USE_FAKE_API"] = "false"
+  rescue StandardError => e
+    warn "Fake API server failed to start (#{e.message}); set USE_FAKE_API=false to use external hosts."
+    ENV["USE_FAKE_API"] = "false"
+  end
+end


### PR DESCRIPTION
# Pull Request: nice_http v1.10.0

## Summary

This PR adds **response structure validation** via `NiceHttp.validate_response`, bumps the **nice_hash** dependency to 1.19+, improves **headers initialization** to avoid edge-case errors, and cleans up **dead code** and **specs** (including a local fake API and server for tests).

---

## What’s in this PR

### Added

- **`NiceHttp.validate_response(resp, expected_structure, options)`**  
  Validates that a response body (JSON) matches an expected structure (keys and nesting) using `NiceHash.compare_structure`.  
  - Accepts response as Hash or object with `data` (string or Hash/Array).  
  - Optional `include_diff: true` adds a diff to the result when validation fails.  
  - Returns `{ ok: true }` or `{ ok: false }` (and optionally `{ ok: false, diff: Hash }`).  
  - Implemented in `lib/nice_http/validate_response.rb`, with full specs in `spec/nice_http/validate_response_spec.rb`.

- **README**
  - Section **“Testing with generated data”**: reproducible seed, `generate_n`, UUID with nice_hash/string_pattern.
  - Section **“Validating API responses”**: `compare_structure`, diff, pattern validation.
  - **“Related gems”** note for nice_hash (v1.19+) and string_pattern (v2.4+).

- **Spec support**
  - `spec/support/fake_api.rb` and `spec/support/server.rb` for local, controllable API testing.

- **CHANGELOG**
  - Entries for v1.10.0 (Added / Changed / Removed).

### Changed

- **Dependency:** `nice_hash` is now required as `~> 1.19`, `>= 1.19.0` (was `~> 1.18`, `>= 1.18.4`). **Upgrade nice_hash to 1.19+ when upgrading nice_http.**

- **Headers initialization:** `@headers` is only passed through `generate` when it is a Hash and responds to `generate`; otherwise it is duplicated without calling `generate`. This avoids errors when headers are plain hashes or other types.

- **Specs:** Multiple spec files updated to use the new fake API/server and current patterns (e.g. `capture_spec`, `logs_spec`, method specs, `nice_http_spec`, `stats_spec`, `spec_helper`).

### Removed

- **Dead code:** Removed the branch for Ruby &lt; 2.6.0 in response handling (nice_http already requires Ruby &gt;= 2.7).

---

## Files changed (overview)

| Area | Files |
|------|--------|
| **New feature** | `lib/nice_http/validate_response.rb` |
| **Main lib** | `lib/nice_http.rb`, `lib/nice_http/initialize.rb`, `lib/nice_http/manage/response.rb`, `lib/nice_http/reset.rb` |
| **Gem** | `nice_http.gemspec`, `Gemfile` |
| **Docs** | `README.md`, `CHANGELOG.md` |
| **Specs** | `spec/nice_http/validate_response_spec.rb`, `spec/support/fake_api.rb`, `spec/support/server.rb`, `spec/spec_helper.rb`, plus method/capture/logs/stats/utils specs |

---

## How to test

- Run the test suite (e.g. `bundle exec rspec`).
- Manually: use `NiceHttp.validate_response` on a response and an expected structure; try `include_diff: true` when the structure does not match.

---

## Upgrade note

After merging, consumers must upgrade **nice_hash** to **1.19+** when upgrading to nice_http 1.10.0.
