### PR TITLE
Increase coverage for close and add_stats edge branches

### DIFF
--- a/spec/nice_http/nice_http_spec.rb
+++ b/spec/nice_http/nice_http_spec.rb
@@ -598,6 +598,44 @@ RSpec.describe NiceHttp do
       http = klass.new
       expect { http.close; http.close }.not_to raise_error
     end
+
+    it "close handles nil @http and marks connection as closed" do
+      klass.host = "https://www.example.com"
+      http = klass.new
+      klass.active = 1
+      http.instance_variable_set(:@http, nil)
+      http.instance_variable_set(:@closed, false)
+
+      expect { http.close }.not_to raise_error
+      expect(http.instance_variable_get(:@closed)).to eq true
+      expect(klass.active).to eq 0
+    end
+
+    it "close handles finish exceptions without raising" do
+      klass.host = "https://www.example.com"
+      http = klass.new
+      klass.active = 1
+      broken_http = double("broken_http")
+      allow(broken_http).to receive(:finish).and_raise(StandardError.new("boom"))
+      http.instance_variable_set(:@http, broken_http)
+      http.instance_variable_set(:@closed, false)
+
+      expect { http.close }.not_to raise_error
+      expect(klass.active).to eq 0
+    end
+
+    it "close on already-closed connection does not try to finish again" do
+      klass.host = "https://www.example.com"
+      http = klass.new
+      klass.active = 1
+      already_closed_http = double("already_closed_http")
+      allow(already_closed_http).to receive(:finish).and_raise("should not be called")
+      http.instance_variable_set(:@http, already_closed_http)
+      http.instance_variable_set(:@closed, true)
+
+      expect { http.close }.not_to raise_error
+      expect(klass.active).to eq 0
+    end
   end
 
   describe "inherited" do

--- a/spec/nice_http/stats_spec.rb
+++ b/spec/nice_http/stats_spec.rb
@@ -276,5 +276,22 @@ RSpec.describe NiceHttp do
       expect(klass.stats[:specific][:solo_name][:solo_state][:num]).to eq 1
       expect(klass.stats[:specific][:solo_name][:time_elapsed][:total]).to be >= 1
     end
+
+    it "uses current thread name as item when item is nil" do
+      klass.reset!
+      original_name = Thread.current.name
+      Thread.current.name = "spec-thread-name"
+      started = Time.now - 2
+      finished = Time.now
+
+      klass.add_stats(:thread_case, :ok, started, finished)
+
+      expect(klass.stats[:specific][:thread_case][:time_elapsed][:item_maximum]).to eq "spec-thread-name"
+      expect(klass.stats[:specific][:thread_case][:time_elapsed][:item_minimum]).to eq "spec-thread-name"
+      expect(klass.stats[:specific][:thread_case][:ok][:time_elapsed][:item_maximum]).to eq "spec-thread-name"
+      expect(klass.stats[:specific][:thread_case][:ok][:time_elapsed][:item_minimum]).to eq "spec-thread-name"
+    ensure
+      Thread.current.name = original_name
+    end
   end
 end


### PR DESCRIPTION
## Summary
- add coverage tests for `close` edge paths (`nil @http`, finish exception, already-closed state)
- add coverage test for `add_stats` when `item` is nil and `Thread.current.name` is used

## Test plan
- [x] `bundle exec rspec`

Made with [Cursor](https://cursor.com)